### PR TITLE
Use md5-hex

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ var Q = require('q');
 var path = require('path');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
-var crypto = require('crypto');
+var md5Hex = require('md5-hex');
 var mime = require('mime-types');
 
 var types = require('./types');
@@ -45,9 +45,7 @@ function normFileId(p, opts) {
 
 // Get gravatar url
 function gravatarUrl(email) {
-    var shasum = crypto.createHash('md5');
-    shasum.update(email);
-    return "http://www.gravatar.com/avatar/"+shasum.digest('hex')+"?s=200&d=identicon";
+    return "http://www.gravatar.com/avatar/"+md5Hex(email)+"?s=200&d=identicon";
 }
 
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "axios": "0.5.4",
         "diff-match-patch-node": "0.9.1",
         "mime-types": "2.1.1",
-        "urljoin.js": "0.1.0"
+        "urljoin.js": "0.1.0",
+        "md5-hex": "1.1.0"
     },
     "devDependencies": {
         "mocha": "2.2.1",


### PR DESCRIPTION
Since we only use md5, bundling all of `crypto` is a waste.

## Now 

```
❯ browserify ./lib/index.js | wc -c
 1273282
```

## Without `crypto` and with `md5-hex`

```
❯ browserify ./lib/index.js | wc -c
  833879
```

We get a 33% size reduction for free. This makes the editor 100kb smaller once browserified and gziped.
