### PR TITLE
[WIP] Factor out the state of repofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ node_modules
 
 test/_local
 .tmp
-uhub
+uhub*

--- a/API.md
+++ b/API.md
@@ -1,0 +1,59 @@
+# repofs API
+
+New API after refactor
+
+
+## RepoState
+
+The state of the full working directory is stored in this object. This object is immutable, but remains efficient because of reuse of unchanged values between instances.
+
+It contains the following data:
+
+- `RepoConfig` instance
+- Current branch name
+- Trees for every branch (cached)
+- Pending changes for trees
+- `Store`, to access persistent storage, used for caching (in memory, local storage, etc.)
+
+## RepoConfig
+
+Immutable structure, holding:
+
+- Repository name (`"owner/repo"`)
+- Hostname
+- Committer (name and email)
+- Access token
+
+## Store
+
+TODO How to guarantee the validity of cached values, across multiple instance ?
+Maybe we will need to keep a virtual store index (immutable) to keep track of each cached value, and salt the keys with unique ids ?
+
+An object that must implement the following instance methods:
+
+``` js
+// Returns the namespace being used or ''
+// () -> String
+store.getNamespace = function ()
+
+// Get the data stored for this key
+// String -> x
+store.get = function(key)
+
+// Set the data store for this key
+// String, x -> ()
+store.set = function(key, val)
+
+// Invalidates the current stored value for this key
+// String -> ()
+store.del = function(key)
+```
+
+A new `Store` instance can be created with the following function:
+
+``` js
+// Create a new store, with an optional namespace for stored keys
+// (String) -> Store
+createStore(namespace)
+```
+

--- a/API.md
+++ b/API.md
@@ -1,23 +1,32 @@
-# repofs API
+This document describes the refactored API of `repofs`. We will eventually export it in a proper doc using gitbook.
 
-New API after refactor
+# Overview
 
+## RepoFs
+
+Exposes a set of methods, mostly working on a provided RepoState instance, to do high-level operations on the git repository. Most functions returns Promises.
 
 ## RepoState
 
-The state of the full working directory is stored in this object. This object is immutable, but remains efficient because of reuse of unchanged values between instances.
+The full state of a working directory is stored in this object. This object is immutable, but remains efficient because of reuse of unchanged values between instances.
 
 It contains the following data:
 
 - `RepoConfig` instance
 - Current branch name
-- Trees for every branch (cached)
+- `Trees` for every branch (cached)
 - Pending changes for trees
-- `Store`, to access persistent storage, used for caching (in memory, local storage, etc.)
+- `Store` instance
+
+## Tree
+TODO
+
+## Entry
+TODO
 
 ## RepoConfig
 
-Immutable structure, holding:
+Immutable structure, holding the following state:
 
 - Repository name (`"owner/repo"`)
 - Hostname
@@ -26,12 +35,46 @@ Immutable structure, holding:
 
 ## Store
 
+Gives access to persistent storage, used for caching (in memory, local storage, etc.)
+
 TODO How to guarantee the validity of cached values, across multiple instance ?
 Maybe we will need to keep a virtual store index (immutable) to keep track of each cached value, and salt the keys with unique ids ?
 
+# API details
+
+## Types
+
+```js
+// As in Git. Has a name and type: remote, tag, head...
+Ref = String
+
+// A SHA hash
+Sha = String
+
+// A file path like 'folder/README.md'
+Path = String
+
+// A file and its info
+File = {
+    name: String,
+    path: Path,
+    type: String, // "file", etc?
+    isDirectory: Boolean,
+    size: Number, // Characters count
+    sha: Sha,
+    content: String,
+    mime: String, // like "application/octet-stream"
+    url: String // "protocol://..."
+
+}
+```
+
+with protocol being The `url` can be an `http(s)` url (for GitHub), or a `data` url (for Memory and LocalStore).
+
+## `Store`
 An object that must implement the following instance methods:
 
-``` js
+```js
 // Returns the namespace being used or ''
 // () -> String
 store.getNamespace = function ()
@@ -51,9 +94,59 @@ store.del = function(key)
 
 A new `Store` instance can be created with the following function:
 
-``` js
+```js
 // Create a new store, with an optional namespace for stored keys
 // (String) -> Store
 createStore(namespace)
 ```
 
+## RepoState
+
+### Static methods
+
+```js
+TODO
+```
+
+### Instance methods
+
+```js
+// () -> RepoConfig
+state.getConfig()
+
+// Get the current ref, most methods default to using this ref
+// () -> Ref
+state.getCurrentRef()
+
+// () -> [Ref]
+state.listRefs()
+
+// optional ref param
+// (Ref) -> Tree
+state.getTree(ref)
+
+// optional ref param
+// (Ref) -> Tree // TODO return a Tree ?
+state.getPendingChanges(ref)
+
+// () -> Store
+state._getStore()
+```
+
+## RepoFs
+
+```js
+// RepoConfig -> RepoState
+RepoFs.createFromConfig = function (repoConfig)
+```
+
+```js
+// RepoState, Ref -> RepoState
+RepoFs.checkout = function (repoState, ref)
+```
+
+```js
+// Get information about a file
+// RepoState, Path -> Promise(File)
+RepoFs.stat(repoState, path)
+```

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ var fs = repofs({
 The first step is to select a branch to use:
 
 ```js
-fs.checkout('master').then(function() { ... })
+fs.checkout(repoState, 'master').then(function() { ... })
 ```
 
 ##### fs.stat: Get informations about a file
 
 ```js
-fs.stat('README.txt').then(function(file) { ... });
+fs.stat(repoState, 'README.txt').then(function(file) { ... });
 ```
 
 `file` will look like:
@@ -81,30 +81,30 @@ The `url` can be an `http(s)` url (for GitHub), or a `data` url (for Memory and 
 ##### fs.read: Read file's content
 
 ```js
-fs.read('README.txt').then(function(content) { ... });
+fs.read(repoState, 'README.txt').then(function(content) { ... });
 ```
 
 By default content is returned as an utf8 string, to read file's content as an `ArrayBuffer`, you can use the `encoding` option:
 
 ```js
 // Get content as an ArrayBuffer
-fs.read('README.txt', { encoding: null })
+fs.read(repoState, 'README.txt', { encoding: null })
 ```
 
 ##### fs.write: Update file content
 
-This method will fail if the file doesnt't exist. If the file doesn't exists, you should use `fs.create`. You can also use `fs.update` to orce creation if file doesn't exist.
+This method will fail if the file doesnt't exist. If the file doesn't exists, you should use `fs.create`. You can also use `fs.update` to force creation if file doesn't exist.
 
 ```js
 /// On default branch
-fs.write('README.txt', 'My new content')
+fs.write(repoState, 'README.txt', 'My new content')
 
 // With a specific commit message
 // By default, the message will be "Update <path>"
-fs.write('README.txt', 'My new content', { message: "My super commit" })
+fs.write(repoState, 'README.txt', 'My new content', { message: "My super commit" })
 
 // With an binary array buffer
-fs.write('image.png', new ArrayBuffer(10));
+fs.write(repoState, 'image.png', new ArrayBuffer(10));
 ```
 
 ##### fs.commit: Commit changes
@@ -114,36 +114,36 @@ Commit all changes to the driver.
 ```js
 // Commit changes on a specific branch
 // Commit message will be the last change's message
-fs.commit()
+fs.commit(repoState)
 
 // Commit with a different message
-fs.commit({ message: 'My Commit' })
+fs.commit(repoState, { message: 'My Commit' })
 ```
 
 ##### fs.exists: Check if a file exists
 
 ```js
-fs.exists('README.txt').then(function(exist) { ... });
+fs.exists(repoState, 'README.txt').then(function(exist) { ... });
 ```
 
 ##### fs.readdir: List directory content
 
 ```js
-fs.readdir('myfolder').then(function(files) { ... });
+fs.readdir(repoState, 'myfolder').then(function(files) { ... });
 ```
 
-`files` is a map fo `fileName => fileInfos`.
+`files` is a map of `fileName => fileInfos`.
 
 ##### fs.unlink: Delete a file
 
 ```js
-fs.unlink('README.txt').then(function() { ... });
+fs.unlink(repoState, 'README.txt').then(function(newState) { ... });
 ```
 
 ##### fs.rmdir: Delete a folder
 
 ```js
-fs.rmdir('lib').then(function() { ... });
+fs.rmdir(repoState, 'lib').then(function(newState) { ... });
 ```
 
 ##### fs.move: Move/Rename a file
@@ -151,32 +151,32 @@ fs.rmdir('lib').then(function() { ... });
 (`fs.rename` is an alias of this method).
 
 ```js
-fs.move('README.txt', 'README2.txt').then(function() { ... });
+fs.move(repoState, 'README.txt', 'README2.txt').then(function(newState) { ... });
 ```
 
 ##### fs.mvdir: Move/Rename a directory
 
 ```js
-fs.mvdir('lib', 'lib2').then(function() { ... });
+fs.mvdir(repoState, 'lib', 'lib2').then(function(newState) { ... });
 ```
 
 ##### Working with branches
 
 ```js
 // List branches
-fs.listBranches().then(function(branches) { ... });
+fs.listBranches(repoState, ).then(function(branches) { ... });
 
 // Create a new branch from master
-fs.createBranch('dev')
+fs.createBranch(repoState, 'dev')
 
 // or create a new branch from another branch
-fs.createBranch('fix/2', 'dev')
+fs.createBranch(repoState, 'fix/2', 'dev')
 
 // Delete a branch
-fs.removeBranch('dev')
+fs.removeBranch(repoState, 'dev')
 
 // Merge a branch into another one
-fs.mergeBranches('dev', 'master', { message: 'Merges dev into master' })
+fs.mergeBranches(repoState, 'dev', 'master', { message: 'Merges dev into master' })
 ```
 
 A branch is defined by:
@@ -194,10 +194,11 @@ When commiting, or merging two branches, and conflicts occur, `fs` emits a `'con
 
 - `conflicts`: the result of comparing the conflicting refs (see `fs.detectConflicts()`)
 - `next`: callback method, expecting the resolved object:
+// TODO provide a fail callback too ?
 
 ``` js
 // Provides err to fail
-next = function (err, resolved)
+next = function (err, resolved) // TODO pass a new editor state instead of just resolved ?
 
 var resolved = {
     message: 'Commit message'
@@ -217,7 +218,7 @@ If no one is listening, the operations will simply fail.
 
 ``` js
 // Detect conflicts between two refs (branch name or sha)
-fs.detectConflicts("master", "dev")
+fs.detectConflicts(repoState, "master", "dev")
 ```
 
 This returns one of the possible status between the two refs, along with the list of conflicts:
@@ -243,7 +244,7 @@ This returns one of the possible status between the two refs, along with the lis
 
 ```js
 // List commits
-fs.listCommits({ ref: "dev" }).then(function(commits) { ... });
+fs.listCommits(repoState, { ref: "dev" }).then(function(commits) { ... });
 ```
 
 `commits` will be a list of objects like:
@@ -263,7 +264,7 @@ fs.listCommits({ ref: "dev" }).then(function(commits) { ... });
 ##### Get a single commit
 
 ```js
-fs.getCommit("sha").then(function(commit) { ... });
+fs.getCommit(repoState, "sha").then(function(commit) { ... });
 ```
 
 `commit` will also include a `files` attribute, example:
@@ -289,7 +290,7 @@ fs.getCommit("sha").then(function(commit) { ... });
 ##### Compare two commits
 
 ```js
-fs.compareCommits("hubot:branchname", "octocat:branchname").then(function(result) { ... });
+fs.compareCommits(repoState, "hubot:branchname", "octocat:branchname").then(function(result) { ... });
 ```
 
 `result` will also include `files` and `commits` attribute.
@@ -299,12 +300,12 @@ fs.compareCommits("hubot:branchname", "octocat:branchname").then(function(result
 
 ```js
 // Push a branch to origin
-fs.push({
+fs.push(repoState, {
     branch: "dev"
 })
 
 // Push to a specific remote
-fs.push({
+fs.push(repoState, {
     remote: {
         name: "myremote",
         url: "https://github.com/GitbookIO/repofs.git"
@@ -312,7 +313,7 @@ fs.push({
 })
 
 // Fetch a specific remote with authentication
-fs.fetch({
+fs.fetch(repoState, {
     remote: {
         name: "myremote",
         url: "https://github.com/GitbookIO/repofs.git"
@@ -324,7 +325,7 @@ fs.fetch({
 })
 
 // Force push
-fs.push({
+fs.push(repoState, {
     force: true
 })
 ```
@@ -336,7 +337,7 @@ fs.push({
 Uncommited changes can be listed:
 
 ```js
-var changes = fs.listChanges({ ref: 'master' });
+var changes = fs.listChanges(repoState, { ref: 'master' });
 // changes will be a map: filanem -> {type, buffer}
 ```
 
@@ -344,27 +345,39 @@ And revert:
 
 ```js
 // Revert change on a file
-fs.revertChange('README.md', { ref: 'master' });
+fs.revertChange(repoState, 'README.md', { ref: 'master' });
 
 // Revert all pending changes
-fs.revertChanges({ ref: 'master' });
+fs.revertChanges(repoState, { ref: 'master' });
 ```
 
 ##### Operations
 
 Repofs has a concept of "operations stack", to easily group changes:
 
-```js
+// TODO this feature might not be kept, at least not in this form
+``` js
 fs.operation('First commit', function() {
     return Q.all([
         fs.write('package.json', '{ ... }'),
         fs.write('index.js', '...'),
         fs.write('README.md', '...')
-    ]);
-});
+     ]);
+ });
 ```
 
-We can also automatically commit once the stack is empty:
+// TODO this would be the alternative form
+```js
+fs.operation(repoState, 'First commit', function() {
+    fs.write(repoState, 'package.json', '{ ... }')
+    .then(function (newState) {
+        return fs.write(newState, 'index.js', '...')
+    })
+    .then(function (newState) {
+        return fs.write(newState, README.js', '...')
+    })
+}).then(function (finalState) { ... })
+```
 
 ```js
 fs.on('operations.allcompleted', function() {
@@ -373,6 +386,8 @@ fs.on('operations.allcompleted', function() {
 ```
 
 ##### Events
+
+// TODO we must define how we refactor events...
 
 File watcher (Path of the file is accessible using `e.path`):
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ The API provided by this module is Promise-based.
 - :sparkles: Supports ArrayBuffer for reading/writing files without encoding issues
 - :sparkles: Bundle multiple changes in one commit
 - :sparkles: Merge conflicts and "Can not fast forward"
-- :sparkles: External state
 
 ### Installation
 
@@ -51,13 +50,13 @@ var fs = repofs({
 The first step is to select a branch to use:
 
 ```js
-fs.checkout(repoState, 'master').then(function() { ... })
+fs.checkout('master').then(function() { ... })
 ```
 
 ##### fs.stat: Get informations about a file
 
 ```js
-fs.stat(repoState, 'README.txt').then(function(file) { ... });
+fs.stat('README.txt').then(function(file) { ... });
 ```
 
 `file` will look like:
@@ -81,30 +80,30 @@ The `url` can be an `http(s)` url (for GitHub), or a `data` url (for Memory and 
 ##### fs.read: Read file's content
 
 ```js
-fs.read(repoState, 'README.txt').then(function(content) { ... });
+fs.read('README.txt').then(function(content) { ... });
 ```
 
 By default content is returned as an utf8 string, to read file's content as an `ArrayBuffer`, you can use the `encoding` option:
 
 ```js
 // Get content as an ArrayBuffer
-fs.read(repoState, 'README.txt', { encoding: null })
+fs.read('README.txt', { encoding: null })
 ```
 
 ##### fs.write: Update file content
 
-This method will fail if the file doesnt't exist. If the file doesn't exists, you should use `fs.create`. You can also use `fs.update` to force creation if file doesn't exist.
+This method will fail if the file doesnt't exist. If the file doesn't exists, you should use `fs.create`. You can also use `fs.update` to orce creation if file doesn't exist.
 
 ```js
 /// On default branch
-fs.write(repoState, 'README.txt', 'My new content')
+fs.write('README.txt', 'My new content')
 
 // With a specific commit message
 // By default, the message will be "Update <path>"
-fs.write(repoState, 'README.txt', 'My new content', { message: "My super commit" })
+fs.write('README.txt', 'My new content', { message: "My super commit" })
 
 // With an binary array buffer
-fs.write(repoState, 'image.png', new ArrayBuffer(10));
+fs.write('image.png', new ArrayBuffer(10));
 ```
 
 ##### fs.commit: Commit changes
@@ -114,36 +113,36 @@ Commit all changes to the driver.
 ```js
 // Commit changes on a specific branch
 // Commit message will be the last change's message
-fs.commit(repoState)
+fs.commit()
 
 // Commit with a different message
-fs.commit(repoState, { message: 'My Commit' })
+fs.commit({ message: 'My Commit' })
 ```
 
 ##### fs.exists: Check if a file exists
 
 ```js
-fs.exists(repoState, 'README.txt').then(function(exist) { ... });
+fs.exists('README.txt').then(function(exist) { ... });
 ```
 
 ##### fs.readdir: List directory content
 
 ```js
-fs.readdir(repoState, 'myfolder').then(function(files) { ... });
+fs.readdir('myfolder').then(function(files) { ... });
 ```
 
-`files` is a map of `fileName => fileInfos`.
+`files` is a map fo `fileName => fileInfos`.
 
 ##### fs.unlink: Delete a file
 
 ```js
-fs.unlink(repoState, 'README.txt').then(function(newState) { ... });
+fs.unlink('README.txt').then(function() { ... });
 ```
 
 ##### fs.rmdir: Delete a folder
 
 ```js
-fs.rmdir(repoState, 'lib').then(function(newState) { ... });
+fs.rmdir('lib').then(function() { ... });
 ```
 
 ##### fs.move: Move/Rename a file
@@ -151,32 +150,32 @@ fs.rmdir(repoState, 'lib').then(function(newState) { ... });
 (`fs.rename` is an alias of this method).
 
 ```js
-fs.move(repoState, 'README.txt', 'README2.txt').then(function(newState) { ... });
+fs.move('README.txt', 'README2.txt').then(function() { ... });
 ```
 
 ##### fs.mvdir: Move/Rename a directory
 
 ```js
-fs.mvdir(repoState, 'lib', 'lib2').then(function(newState) { ... });
+fs.mvdir('lib', 'lib2').then(function() { ... });
 ```
 
 ##### Working with branches
 
 ```js
 // List branches
-fs.listBranches(repoState, ).then(function(branches) { ... });
+fs.listBranches().then(function(branches) { ... });
 
 // Create a new branch from master
-fs.createBranch(repoState, 'dev')
+fs.createBranch('dev')
 
 // or create a new branch from another branch
-fs.createBranch(repoState, 'fix/2', 'dev')
+fs.createBranch('fix/2', 'dev')
 
 // Delete a branch
-fs.removeBranch(repoState, 'dev')
+fs.removeBranch('dev')
 
 // Merge a branch into another one
-fs.mergeBranches(repoState, 'dev', 'master', { message: 'Merges dev into master' })
+fs.mergeBranches('dev', 'master', { message: 'Merges dev into master' })
 ```
 
 A branch is defined by:
@@ -194,11 +193,10 @@ When commiting, or merging two branches, and conflicts occur, `fs` emits a `'con
 
 - `conflicts`: the result of comparing the conflicting refs (see `fs.detectConflicts()`)
 - `next`: callback method, expecting the resolved object:
-// TODO provide a fail callback too ?
 
 ``` js
 // Provides err to fail
-next = function (err, resolved) // TODO pass a new editor state instead of just resolved ?
+next = function (err, resolved)
 
 var resolved = {
     message: 'Commit message'
@@ -218,7 +216,7 @@ If no one is listening, the operations will simply fail.
 
 ``` js
 // Detect conflicts between two refs (branch name or sha)
-fs.detectConflicts(repoState, "master", "dev")
+fs.detectConflicts("master", "dev")
 ```
 
 This returns one of the possible status between the two refs, along with the list of conflicts:
@@ -244,7 +242,7 @@ This returns one of the possible status between the two refs, along with the lis
 
 ```js
 // List commits
-fs.listCommits(repoState, { ref: "dev" }).then(function(commits) { ... });
+fs.listCommits({ ref: "dev" }).then(function(commits) { ... });
 ```
 
 `commits` will be a list of objects like:
@@ -264,7 +262,7 @@ fs.listCommits(repoState, { ref: "dev" }).then(function(commits) { ... });
 ##### Get a single commit
 
 ```js
-fs.getCommit(repoState, "sha").then(function(commit) { ... });
+fs.getCommit("sha").then(function(commit) { ... });
 ```
 
 `commit` will also include a `files` attribute, example:
@@ -290,7 +288,7 @@ fs.getCommit(repoState, "sha").then(function(commit) { ... });
 ##### Compare two commits
 
 ```js
-fs.compareCommits(repoState, "hubot:branchname", "octocat:branchname").then(function(result) { ... });
+fs.compareCommits("hubot:branchname", "octocat:branchname").then(function(result) { ... });
 ```
 
 `result` will also include `files` and `commits` attribute.
@@ -300,12 +298,12 @@ fs.compareCommits(repoState, "hubot:branchname", "octocat:branchname").then(func
 
 ```js
 // Push a branch to origin
-fs.push(repoState, {
+fs.push({
     branch: "dev"
 })
 
 // Push to a specific remote
-fs.push(repoState, {
+fs.push({
     remote: {
         name: "myremote",
         url: "https://github.com/GitbookIO/repofs.git"
@@ -313,7 +311,7 @@ fs.push(repoState, {
 })
 
 // Fetch a specific remote with authentication
-fs.fetch(repoState, {
+fs.fetch({
     remote: {
         name: "myremote",
         url: "https://github.com/GitbookIO/repofs.git"
@@ -325,7 +323,7 @@ fs.fetch(repoState, {
 })
 
 // Force push
-fs.push(repoState, {
+fs.push({
     force: true
 })
 ```
@@ -337,7 +335,7 @@ fs.push(repoState, {
 Uncommited changes can be listed:
 
 ```js
-var changes = fs.listChanges(repoState, { ref: 'master' });
+var changes = fs.listChanges({ ref: 'master' });
 // changes will be a map: filanem -> {type, buffer}
 ```
 
@@ -345,39 +343,27 @@ And revert:
 
 ```js
 // Revert change on a file
-fs.revertChange(repoState, 'README.md', { ref: 'master' });
+fs.revertChange('README.md', { ref: 'master' });
 
 // Revert all pending changes
-fs.revertChanges(repoState, { ref: 'master' });
+fs.revertChanges({ ref: 'master' });
 ```
 
 ##### Operations
 
 Repofs has a concept of "operations stack", to easily group changes:
 
-// TODO this feature might not be kept, at least not in this form
-``` js
+```js
 fs.operation('First commit', function() {
     return Q.all([
         fs.write('package.json', '{ ... }'),
         fs.write('index.js', '...'),
         fs.write('README.md', '...')
-     ]);
- });
+    ]);
+});
 ```
 
-// TODO this would be the alternative form
-```js
-fs.operation(repoState, 'First commit', function() {
-    fs.write(repoState, 'package.json', '{ ... }')
-    .then(function (newState) {
-        return fs.write(newState, 'index.js', '...')
-    })
-    .then(function (newState) {
-        return fs.write(newState, README.js', '...')
-    })
-}).then(function (finalState) { ... })
-```
+We can also automatically commit once the stack is empty:
 
 ```js
 fs.on('operations.allcompleted', function() {
@@ -386,8 +372,6 @@ fs.on('operations.allcompleted', function() {
 ```
 
 ##### Events
-
-// TODO we must define how we refactor events...
 
 File watcher (Path of the file is accessible using `e.path`):
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The API provided by this module is Promise-based.
 - :sparkles: Supports ArrayBuffer for reading/writing files without encoding issues
 - :sparkles: Bundle multiple changes in one commit
 - :sparkles: Merge conflicts and "Can not fast forward"
+- :sparkles: External state
 
 ### Installation
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,7 +99,7 @@ Fs.prototype.doFetchTree = decorators.uniqueOp('fetchTree', function fetchTree(o
     this.working.setCurrentBranch(opts.branch);
 
     // Load tree from cache
-    var cachedTree = this.working.get();
+    var cachedTree = this.working.getTree();
 
     // If no update required, take tree from cache
     if (!opts.update) {
@@ -133,7 +133,7 @@ Fs.prototype.fetchTree = function(opts) {
 
     return this.doFetchTree(opts)
     .then(function() {
-        return that.working.get();
+        return that.working.getTree();
     });
 };
 

--- a/lib/repostate.js
+++ b/lib/repostate.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var Immutable = require('immutable');
+var Record = Immutable.Record;
+
+var defaultState = {
+    currentBranch: null // string
+};
+
+var RepoStateRecord = Record(defaultState);
+
+/**
+ * Constructor not for public consumption.
+ * RepoStateRecord -> RepoState
+ */
+var RepoState = function (immutable) {
+    this._immutable = immutable;
+};
+
+// Static methods //
+
+/**
+ * Creates a new RepoState with initialised current branch
+ * String -> RepoState
+ */
+RepoState.createWithCurrentBranch = function (currentBranch) {
+    return new RepoState(new RepoStateRecord({
+        currentBranch: currentBranch
+    }));
+};
+
+/**
+ * Set properties of the repoState to new values
+ * RepoState, Object -> RepoState
+ */
+RepoState.set = function (repoState, put) {
+    // TODO use Map.withMutations()
+    var map = repoState.getImmutable().merge(put);
+    return new RepoState(map);
+};
+
+RepoState.prototype.setCurrentBranch = function (repoState, branch) {
+    return RepoState.set(repoState, { currentBranch: branch });
+};
+
+// Instance methods
+
+/**
+ * Not for public consumption.
+ * This -> RepoStateRecord
+ */
+RepoState.prototype.getImmutable = function() {
+    return this._immutable;
+};
+
+
+
+RepoState.prototype.getCurrentBranch = function () {
+    return this.getImmutable().get('currentBranch');
+};
+
+
+module.exports = RepoState;

--- a/lib/working.js
+++ b/lib/working.js
@@ -39,7 +39,7 @@ WorkingTree.prototype.setCurrentBranch = function(name) {
 
 // Return sha of current branch
 WorkingTree.prototype.head = function() {
-    return this.get().sha;
+    return this.getTree().sha;
 };
 
 // Update current tree with a new fetched tree
@@ -50,7 +50,7 @@ WorkingTree.prototype.fetch = function(branch, tree) {
 
 // Return tree merged with changes
 WorkingTree.prototype.getActive = function() {
-    var tree = this.get();
+    var tree = this.getTree();
 
     // Apply all changes
     _.each(tree.changes, function(change, filePath) {
@@ -160,7 +160,7 @@ WorkingTree.prototype.move = function move(from, to, msg) {
 
 // Revert change for a specific file
 WorkingTree.prototype.revertChange = function(filePath) {
-    var tree = this.get();
+    var tree = this.getTree();
     filePath = pathUtils.norm(filePath);
 
     if (!tree.changes[filePath]) return;
@@ -183,7 +183,7 @@ WorkingTree.prototype.revertChange = function(filePath) {
 
 // Revert all changes in a directory
 WorkingTree.prototype.revertFolderChanges = function(dirPath) {
-    var tree = this.get();
+    var tree = this.getTree();
 
     _.each(_.keys(tree.changes), function(filePath) {
         if (!pathUtils.contains(dirPath, filePath)) return;
@@ -193,7 +193,7 @@ WorkingTree.prototype.revertFolderChanges = function(dirPath) {
 
 // Revert all changes for a specific type (or all types)
 WorkingTree.prototype.revertChanges = function(type) {
-    var tree = this.get();
+    var tree = this.getTree();
 
     _.each(_.keys(tree.changes), function(filePath) {
         if (type && tree.changes[filePath].type != type) return;
@@ -203,7 +203,7 @@ WorkingTree.prototype.revertChanges = function(type) {
 
 // List pending changes
 WorkingTree.prototype.listChanges = function(ref) {
-    var tree = this.get(ref);
+    var tree = this.getTree(ref);
     return tree.changes || {};
 };
 
@@ -271,7 +271,7 @@ WorkingTree.prototype.completeOp = function() {
 
 // Get last operation
 WorkingTree.prototype.getLastOperation = function() {
-    return this.get().lastOperation;
+    return this.getTree().lastOperation;
 };
 
 // Wrap a function as an operation
@@ -291,7 +291,7 @@ WorkingTree.prototype.operation = function(msg, fn) {
 
 // Update tree in cache
 WorkingTree.prototype.update = function(fn) {
-    var tree = this.get();
+    var tree = this.getTree();
     var newTree = fn(tree);
     if (newTree === false) return;
 
@@ -309,8 +309,8 @@ WorkingTree.prototype.destroy = function() {
 };
 
 // Load tree in cache
-WorkingTree.prototype.get = function() {
-    var ref = this.currentBranch;
+WorkingTree.prototype.getTree = function(ref) {
+    ref = ref || this.currentBranch;
 
     var tree = this.getCache('tree.' + ref, {});
     if (!tree) return null;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     },
     "scripts": {
         "test": "./scripts/test-uhub.sh; ./scripts/test-github.sh",
+        "test-internal": "./scripts/test-internal.sh",
         "test-uhub": "./scripts/test-uhub.sh",
         "test-github": "./scripts/test-github.sh"
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "github-releases": "0.3.2"
     },
     "scripts": {
-        "test": "./scripts/test-uhub.sh; ./scripts/test-github.sh",
+        "test": "./scripts/test-uhub.sh && ./scripts/test-github.sh",
         "test-internal": "./scripts/test-internal.sh",
         "test-uhub": "./scripts/test-uhub.sh",
         "test-github": "./scripts/test-github.sh"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dependencies": {
         "q": "^1.3.0",
         "lodash": "^3.9.3",
+        "immutable": "^3.7.6",
         "axios": "0.8.0",
         "diff-match-patch-node": "0.9.1",
         "mime-types": "2.1.1",

--- a/scripts/test-internal.sh
+++ b/scripts/test-internal.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Only run tests local/internal tests
+
+TESTS=$(find test/ -iname "*.js" | grep -v 'github.js')
+
+mocha --reporter spec $TESTS

--- a/scripts/test-uhub.sh
+++ b/scripts/test-uhub.sh
@@ -22,14 +22,16 @@ elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
     UHUB_NAME=uhub_windows_amd64.exe
 fi
 
-if [ -f uhub ];
+UHUB_BIN="uhub-$UHUB_VERSION"
+
+if [ -f $UHUB_BIN ];
 then
     echo "uhub already exist."
 else
-    echo "Downloading uhub"
+    echo "Downloading uhub version $UHUB_VERSION"
     github-releases --tag $UHUB_VERSION --filename $UHUB_NAME --token $GITHUB_TOKEN download GitbookIO/uhub
-    mv $UHUB_NAME uhub
-    chmod +x uhub
+    mv $UHUB_NAME $UHUB_BIN
+    chmod +x $UHUB_BIN
 fi
 
 echo "Prepare tests for uhub"
@@ -49,7 +51,7 @@ cd ../..
 REPO_PATH=$(pwd)/.tmp/repo/
 
 # Start uhub
-./uhub --mode=single --root=$REPO_PATH --port=127.0.0.1:6666 > /dev/null  &
+./$UHUB_BIN --mode=single --root=$REPO_PATH --port=127.0.0.1:6666 > /dev/null  &
 UHUBPID=$!
 trap 'kill -s 9 $UHUBPID' EXIT
 

--- a/scripts/test-uhub.sh
+++ b/scripts/test-uhub.sh
@@ -11,7 +11,7 @@ EOF
     exit 1
 fi;
 
-UHUB_VERSION=2.2.3
+UHUB_VERSION=2.2.9
 
 # Download Uhub
 if [ "$(uname)" == "Darwin" ]; then

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
 # GitHub Driver
 
-Testing `repofs` requires a GitHub account and a temporary repository (it'll be deleted if existing, then recreate as an empty repo).
+Testing `repofs` requires a GitHub account and a temporary repository (it'll be deleted if existing, then recreated as an empty repo).
 
 ```
 export GITHUB_TOKEN=YourToken

--- a/test/repostate.js
+++ b/test/repostate.js
@@ -1,0 +1,11 @@
+var RepoState = require('../lib/repostate.js');
+
+describe('RepoState module', function() {
+
+    it('should initialize with current branch', function() {
+        var branch = 'master';
+        var state = RepoState.createWithCurrentBranch(branch);
+        state.getCurrentBranch().should.eql(branch);
+    });
+
+});


### PR DESCRIPTION
@AaronO @jpreynat @SamyPesse

# Goal

It would be nice to simplify repofs for future evolutions. We want to pull the state out of the core of repofs, into an independant state value that needs to be passed around.

# Changes
We will change the API so it takes as argument a **state object** and returns a new state in a pure fashion. The API is **still Promise based**.
We will take inspiration in the way `Draft.js` manages its state (in a EditorState object, separate from the Editor object). The state will make use of `Immutable.js`

# Questions

1. The state object is part of the API. Should we expose `Immutable.js` structures directly ? Or only expose standard JS objects and only use `Immutable.js` internally ?
    Update: We will expose standard JS objects
2. How to handle the operation stack and their events (create, update, remove) ?

    We can always keep an operation stack in the state, and delegate the watching to the user of repofs.
    Though it disallows simple parallel operations (like `Q.all(repofs.write(...), repofs.write(...)`), because each operation must use the new state from the previous one.

##### Events

We can ask ourselves if we want to reduce, or remove, the use of Events.

###### Cons of Events

> Since Events break the control flow, it is best to avoid them in cases such as conflicts handling (because it must be tied to an initial action)

But: just incorporate more context to the event.

###### Pros of Events

> They allow any component to plug in and add behavior.

But: then you can lose track of who is listening.

> They can be simply translated to actions in Flux