### PR TITLE
Add API to fetch repository status via uhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ It allows more complex operations than the [Contents API](https://developer.gith
 
 It is powered by an immutable model. Async operations are Promise-based.
 
-### Installation
+## Installation
 
 ```
 $ npm install repofs
 ```
 
-### How to use it?
+## How to use it?
 
 To use `repofs` in the browser, include it using browserify/webpack.
 
@@ -33,7 +33,7 @@ var driver = repofs.GitHubDriver({
 });
 ```
 
-#### Start with an empty RepositoryState
+### Start with an empty RepositoryState
 
 The first step is to create an instance of `RepositoryState`:
 
@@ -41,7 +41,7 @@ The first step is to create an instance of `RepositoryState`:
 var repoState = repofs.RepositoryState.createEmpty();
 ```
 
-#### Fetch the list of branches
+### Fetch the list of branches
 
 After creating a `RepositoryState`, the next step is to fetch the list of existing branches.
 
@@ -53,7 +53,7 @@ repofs.RepoUtils.fetchBranches(repoState, driver)
 })
 ```
 
-#### Checkout a branch
+### Checkout a branch
 
 Once the branches are fetched, you can checkout one. **This requires to fetch it first** using `repofs.RepoUtils.fetchTree`. This overrides any existing working tree for this branch. The `repofs.RepoUtils.checkout` operation is always sync.
 
@@ -67,7 +67,7 @@ repofs.RepoUtils.fetchTree(repoState, driver, branch)
 })
 ```
 
-#### Quick initialization
+### Quick initialization
 
 There is a short way to initialize a `RepositoryState` from a driver, that will fetch the list of the branches, then fetch and checkout *master* or the first available branch.
 
@@ -79,7 +79,7 @@ repofs.RepoUtils.initialize(driver)
 });
 ```
 
-#### Reading files
+### Reading files
 
 Reading a file requires to fetch the content from the remote repository inside the `RepositoryState` (See [Caching](#caching)):
 
@@ -100,7 +100,7 @@ var blob = repofs.FileUtils.read(repoState, 'README.md');
 var content = repofs.FileUtils.readAsString(repoState, 'README.md');
 ```
 
-#### Listing files
+### Listing files
 
 repofs keeps the whole trees in the different `WorkingStates`, you can access the whole tree as a flat list...
 
@@ -116,7 +116,7 @@ var dir = '.' // root
 var rootTree = repofs.TreeUtils.get(repoState, dir);
 ```
 
-#### Working with files
+### Working with files
 
 Create a new file:
 
@@ -142,7 +142,7 @@ Rename/Move the file
 var newRepoState = repofs.FileUtils.move(repoState, 'API.md', 'API2.md');
 ```
 
-#### Working with directories
+### Working with directories
 
 List files in the directory
 
@@ -162,7 +162,7 @@ Rename/Move the directory
 var newRepoState = repofs.DirUtils.move(repoState, 'myfolder', 'myfolder2');
 ```
 
-#### Changes
+### Changes
 
 Until being commited, repofs keeps a record of changes per files.
 
@@ -182,7 +182,7 @@ var newRepoState = repofs.ChangeUtils.revertForFile(repoState, 'README.md');
 var newRepoState = repofs.ChangeUtils.revertForDir(repoState, 'src');
 ```
 
-#### Commiting changes
+### Commiting changes
 
 ```js
 // Create an author / committer
@@ -202,7 +202,7 @@ repofs.CommitUtils.flush(repoState, driver, commitBuilder)
 });
 ```
 
-#### Manipulating branches
+### Manipulating branches
 
 ``` js
  // Create a branch from current branch
@@ -220,7 +220,7 @@ repofs.CommitUtils.flush(repoState, driver, commitBuilder)
 });
 ```
 
-#### Non fast forward commits
+### Non fast forward commits
 
 Flushing a commit can fail with an `ERRORS.NOT_FAST_FORWARD` code.
 
@@ -258,7 +258,7 @@ Non fast forward errors contains the created commit (that is currently not linke
 }
 ```
 
-#### Merging
+### Merging
 
 `repofs.BranchUtils.merge` allows to automatically merge a commit or a branch, into another branch.
 
@@ -270,7 +270,7 @@ repofs.BranchUtils.merge(repoState, driver, from, into)
 });
 ```
 
-#### Merge conflicts
+### Merge conflicts
 
 But conflicts can happen when the automatic merge failed. For example, after merging two branches, or after merging a non fast forward commit. It is possible then to solve the conflicts manually:
 
@@ -315,11 +315,11 @@ function solveConflicts(repoState, driver, from, into) {
 }
 ```
 
-#### Remotes operations
+### Remotes operations
 
 When using a compatible API, you can also deal with remotes on the repository.
 
-##### List remotes
+#### List remotes
 
 ``` js
 repofs.RemoteUtils.list(driver)
@@ -332,7 +332,7 @@ repofs.RemoteUtils.list(driver)
 });
 ```
 
-##### Edit remotes
+#### Edit remotes
 
 ``` js
 repofs.RemoteUtils.edit(driver, name, url)
@@ -341,7 +341,7 @@ repofs.RemoteUtils.edit(driver, name, url)
 });
 ```
 
-##### Pulling
+#### Pulling
 
 You can update a branch to the state of the same branch on a remote, and get an updated `RepositoryState` with:
 
@@ -364,7 +364,7 @@ repofs.RemoteUtils.pull(repoState, driver, {
 })
 ```
 
-##### Pushing
+#### Pushing
 
 You can push a branch to a remote:
 
@@ -386,3 +386,14 @@ repofs.RemoteUtils.push(repoState, driver, {
     // Pushed
 })
 ```
+
+## Contributing
+
+### Run tests
+
+You can run all the tests by providing a `GITHUB_TOKEN` with permission to create and write to a GitHub repository, and running `npm run test`.
+
+You can run tests with GitHub as a backend `npm run test-github`, or Uhub as a backend `npm run test-uhub`.
+
+Finally, you can run the tests without testing the API through the drivers by running `npm run test-no-api`.
+

--- a/lib/drivers/driver.js
+++ b/lib/drivers/driver.js
@@ -191,6 +191,16 @@ Driver.prototype.status = function (opts) {};
  *            }
  *        }
  *
+ * Status and expected behaviour:
+ *
+ * added -> File will be added and committed
+ * copied -> not supported
+ * removed -> File will be removed
+ * modified -> Modification will be committed
+ * renamed -> not supported
+ * unmodified -> Nothing
+ * untracked -> File will be added and committed
+ *
  * @param {String} opts.message commit message.
  * @param {Array<LocalFile>} opts.files List of files with name and status.
  * @param {Author} opts.author Optional author information with name, email and

--- a/lib/drivers/driver.js
+++ b/lib/drivers/driver.js
@@ -156,4 +156,11 @@ Driver.prototype.pull = function (opts) {};
  */
 Driver.prototype.push = function (opts) {};
 
+/**
+ * Fetch status information from a remote repository
+ * @param {Branch} opts.branch Branch to push. Default to current
+ * @return {Promise<LocalFile>}
+ */
+Driver.prototype.status = function (opts) {};
+
 module.exports = Driver;

--- a/lib/drivers/driver.js
+++ b/lib/drivers/driver.js
@@ -163,4 +163,42 @@ Driver.prototype.push = function (opts) {};
  */
 Driver.prototype.status = function (opts) {};
 
+/**
+ * Track local files into a git repository. Performs a post request to /track
+ * endpoint with a JSON payload in the form of:
+ *
+ *
+ *          {
+ *            "message": "Commit message",
+ *            "files": [{
+ *                "name": "README.md",
+ *                "status": "modified"
+ *            }, {
+ *                "name": "foobar.md",
+ *                "status": "untracked"
+ *            }],
+ *
+ *            "author": {
+ *                "name": "John Doe",
+ *                "email": "johndoe@example.com",
+ *                "date": "Mon Nov 07 2016 16:40:35 GMT+0100 (CET)"
+ *            },
+ *
+ *            "committer": {
+ *                "name": "John Doe",
+ *                "email": "johndoe@example.com",
+ *                "date": "Mon Nov 07 2016 16:40:35 GMT+0100 (CET)"
+ *            }
+ *        }
+ *
+ * @param {String} opts.message List of files with name and status.
+ * @param {Array<LocalFile>} opts.files List of files with name and status.
+ * @param {Author} opts.author Optional author information with name, email and
+ * date.
+ * @param {Author} opts.committer Optional committer information with name,
+ * email and date.
+ * @return {Promise<Undefined>}
+ */
+Driver.prototype.track = function (opts) {};
+
 module.exports = Driver;

--- a/lib/drivers/driver.js
+++ b/lib/drivers/driver.js
@@ -191,7 +191,7 @@ Driver.prototype.status = function (opts) {};
  *            }
  *        }
  *
- * @param {String} opts.message List of files with name and status.
+ * @param {String} opts.message commit message.
  * @param {Array<LocalFile>} opts.files List of files with name and status.
  * @param {Author} opts.author Optional author information with name, email and
  * date.

--- a/lib/drivers/github.js
+++ b/lib/drivers/github.js
@@ -308,6 +308,36 @@ Driver.prototype.status = function (opts) {
         });
 };
 
+Driver.prototype.track = function (opts) {
+    var params = {
+        message: opts.message,
+        files: opts.files.map(function (file) {
+            return {
+                name: file.getFilename(),
+                status: file.getStatus()
+            };
+        }).toJS()
+    };
+
+    if (opts.author) {
+        params.author = {
+            name: opts.author.getName(),
+            email: opts.author.getEmail(),
+            date: opts.author.getDate()
+        };
+    }
+
+    if (opts.committer) {
+        params.committer = {
+            name: opts.author.getName(),
+            email: opts.author.getEmail(),
+            date: opts.author.getDate()
+        };
+    }
+
+    return this.post('track', params);
+};
+
 
 // API utilities
 

--- a/lib/drivers/github.js
+++ b/lib/drivers/github.js
@@ -16,6 +16,7 @@ var Commit = require('../models/commit');
 var Author = require('../models/author');
 var TreeEntry = require('../models/treeEntry');
 var WorkingState = require('../models/workingState');
+var LocalFile = require('../models/localFile');
 
 /**
  * Options for the GitHub Driver
@@ -295,6 +296,16 @@ GitHubDriver.prototype.push = function (opts) {
     .fail(normNotFF)
     .fail(normAuth)
     .fail(normUnknownRemote);
+};
+
+Driver.prototype.status = function (opts) {
+    var branch = opts.branch.getName();
+    return this.get('status/' + branch)
+        .then(function(status) {
+            return new Immutable.List(status.files).map(function(file) {
+                return LocalFile.create(file);
+            });
+        });
 };
 
 

--- a/lib/drivers/github.js
+++ b/lib/drivers/github.js
@@ -298,7 +298,7 @@ GitHubDriver.prototype.push = function (opts) {
     .fail(normUnknownRemote);
 };
 
-Driver.prototype.status = function (opts) {
+GitHubDriver.prototype.status = function (opts) {
     var branch = opts.branch.getName();
     return this.get('status/' + branch)
         .then(function(status) {
@@ -308,7 +308,7 @@ Driver.prototype.status = function (opts) {
         });
 };
 
-Driver.prototype.track = function (opts) {
+GitHubDriver.prototype.track = function (opts) {
     var params = {
         message: opts.message,
         files: opts.files.map(function (file) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ var ERRORS = require('./constants/errors');
 var WorkingUtils = require('./utils/working');
 var TreeUtils = require('./utils/filestree');
 var FileUtils = require('./utils/file');
-var LocalFileUtils = require('./utils/localFile');
+var LocalUtils = require('./utils/localFile');
 var BlobUtils = require('./utils/blob');
 var DirUtils = require('./utils/directory');
 var RepoUtils = require('./utils/repo');
@@ -50,7 +50,7 @@ module.exports = {
     WorkingUtils: WorkingUtils,
     TreeUtils: TreeUtils,
     FileUtils: FileUtils,
-    LocalFileUtils: LocalFileUtils,
+    LocalUtils: LocalUtils,
     BlobUtils: BlobUtils,
     DirUtils: DirUtils,
     RepoUtils: RepoUtils,

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ var ERRORS = require('./constants/errors');
 var WorkingUtils = require('./utils/working');
 var TreeUtils = require('./utils/filestree');
 var FileUtils = require('./utils/file');
+var LocalFileUtils = require('./utils/localFile');
 var BlobUtils = require('./utils/blob');
 var DirUtils = require('./utils/directory');
 var RepoUtils = require('./utils/repo');
@@ -49,6 +50,7 @@ module.exports = {
     WorkingUtils: WorkingUtils,
     TreeUtils: TreeUtils,
     FileUtils: FileUtils,
+    LocalFileUtils: LocalFileUtils,
     BlobUtils: BlobUtils,
     DirUtils: DirUtils,
     RepoUtils: RepoUtils,

--- a/lib/models/localFile.js
+++ b/lib/models/localFile.js
@@ -5,7 +5,7 @@ var mime = require('mime-types');
 var FILETYPE = require('../constants/filetype');
 
 var LocalFile = Immutable.Record({
-    // Commit sha1,
+    // Sha1 of the modified blob,
     sha: null,
 
     // Path of the file

--- a/lib/models/localFile.js
+++ b/lib/models/localFile.js
@@ -1,0 +1,66 @@
+var Immutable = require('immutable');
+var path = require('path');
+var mime = require('mime-types');
+
+var FILETYPE = require('../constants/filetype');
+
+var LocalFile = Immutable.Record({
+    // Commit sha1,
+    sha: null,
+
+    // Path of the file
+    filename: '',
+
+    // File status
+    status: '',
+
+    // Number of additions
+    additions: 0,
+
+    // Number of deletions
+    deletions: 0,
+
+    // Number of changes
+    changes: 0,
+
+    // Git patch to apply
+    patch: ''
+}, 'LocalFile');
+
+// ---- Properties Getter ----
+LocalFile.prototype.getContent = function() {
+    return this.get('content');
+};
+
+LocalFile.prototype.getLocalFileSize = function() {
+    return this.get('fileSize');
+};
+
+LocalFile.prototype.getPath = function() {
+    return this.get('path');
+};
+
+LocalFile.prototype.getType = function() {
+    return this.get('type');
+};
+
+LocalFile.prototype.isDirectory = function() {
+    return this.getType() == FILETYPE.DIRECTORY;
+};
+
+LocalFile.prototype.getMime = function() {
+    return mime.lookup(path.extname(this.getPath())) || 'application/octet-stream';
+};
+
+LocalFile.prototype.getName = function() {
+    return path.basename(this.getPath());
+};
+
+/**
+ * Create a LocalFile representing a status result at the given path (filename etc.)
+ */
+LocalFile.create = function (file) {
+    return new LocalFile(file);
+};
+
+module.exports = LocalFile;

--- a/lib/models/localFile.js
+++ b/lib/models/localFile.js
@@ -28,32 +28,32 @@ var LocalFile = Immutable.Record({
 }, 'LocalFile');
 
 // ---- Properties Getter ----
-LocalFile.prototype.getContent = function() {
-    return this.get('content');
+LocalFile.prototype.getSha = function() {
+    return this.get('sha');
 };
 
-LocalFile.prototype.getLocalFileSize = function() {
-    return this.get('fileSize');
+LocalFile.prototype.getFilename = function() {
+    return this.get('filename');
 };
 
-LocalFile.prototype.getPath = function() {
-    return this.get('path');
+LocalFile.prototype.getStatus = function() {
+    return this.get('status');
 };
 
-LocalFile.prototype.getType = function() {
-    return this.get('type');
+LocalFile.prototype.getAdditions = function() {
+    return this.get('additions');
 };
 
-LocalFile.prototype.isDirectory = function() {
-    return this.getType() == FILETYPE.DIRECTORY;
+LocalFile.prototype.getDeletions = function() {
+    return this.get('deletions');
 };
 
-LocalFile.prototype.getMime = function() {
-    return mime.lookup(path.extname(this.getPath())) || 'application/octet-stream';
+LocalFile.prototype.getChanges = function() {
+    return this.get('changes');
 };
 
-LocalFile.prototype.getName = function() {
-    return path.basename(this.getPath());
+LocalFile.prototype.getPatch = function() {
+    return this.get('patch');
 };
 
 /**

--- a/lib/utils/localFile.js
+++ b/lib/utils/localFile.js
@@ -21,3 +21,23 @@ LocalUtils.status = function status(repoState, driver) {
         branch: branch
     });
 };
+
+/**
+ * Perform a git status on a given repository branch
+ *
+ * @param {RepositoryState} repoState
+ * @param {Driver} driver
+ * @return {Promise<List<LocalFile>>}
+ */
+LocalUtils.track = function track(driver, files, message, author) {
+    files = files.map(function (file) {
+        return LocalFile.create(file);
+    });
+
+    return driver.track({
+        message: message,
+        files: files,
+        author: author,
+        committer: author
+    });
+};

--- a/lib/utils/localFile.js
+++ b/lib/utils/localFile.js
@@ -1,0 +1,23 @@
+var FILETYPE = require('../constants/filetype');
+var LocalFile = require('../models/localFile');
+var Branch = require('../models/branch');
+
+var LocalFileUtils = module.exports;
+
+/**
+ * Perform a git status on a given repository branch
+ *
+ * @param {RepositoryState} repoState
+ * @param {Driver} driver
+ * @return {Promise<List<LocalFile>>}
+ */
+LocalFileUtils.status = function status(repoState, driver) {
+    var branchName = repoState.getCurrentBranchName();
+    var branch = new Branch({
+        name: branchName
+    });
+
+    return driver.status({
+        branch: branch
+    });
+};

--- a/lib/utils/localFile.js
+++ b/lib/utils/localFile.js
@@ -2,7 +2,7 @@ var FILETYPE = require('../constants/filetype');
 var LocalFile = require('../models/localFile');
 var Branch = require('../models/branch');
 
-var LocalFileUtils = module.exports;
+var LocalUtils = module.exports;
 
 /**
  * Perform a git status on a given repository branch
@@ -11,7 +11,7 @@ var LocalFileUtils = module.exports;
  * @param {Driver} driver
  * @return {Promise<List<LocalFile>>}
  */
-LocalFileUtils.status = function status(repoState, driver) {
+LocalUtils.status = function status(repoState, driver) {
     var branchName = repoState.getCurrentBranchName();
     var branch = new Branch({
         name: branchName

--- a/lib/utils/localFile.js
+++ b/lib/utils/localFile.js
@@ -1,4 +1,3 @@
-var FILETYPE = require('../constants/filetype');
 var LocalFile = require('../models/localFile');
 var Branch = require('../models/branch');
 

--- a/lib/utils/localFile.js
+++ b/lib/utils/localFile.js
@@ -23,11 +23,13 @@ LocalUtils.status = function status(repoState, driver) {
 };
 
 /**
- * Perform a git status on a given repository branch
+ * Perform track / untrack of working directory.
  *
  * @param {RepositoryState} repoState
  * @param {Driver} driver
- * @return {Promise<List<LocalFile>>}
+ * @param {String} message
+ * @param {Author} author
+ * @return {Promise}
  */
 LocalUtils.track = function track(driver, files, message, author) {
     files = files.map(function (file) {

--- a/scripts/download-uhub.sh
+++ b/scripts/download-uhub.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 IFS=$'\n\t'
 
-UHUB_VERSION=2.3.1
+UHUB_VERSION=2.5.1
 
 # Download Uhub
 if [ "$(uname)" == "Darwin" ]; then

--- a/test/api.js
+++ b/test/api.js
@@ -8,7 +8,9 @@
  './filestree.js',
  './conflict.js',
  './repository.js',
- './workingState.js']
+ './workingState.js',
+ './localFile'
+]
 .map(require);
 
 var repofs = require('../');

--- a/test/api.js
+++ b/test/api.js
@@ -8,8 +8,7 @@
  './filestree.js',
  './conflict.js',
  './repository.js',
- './workingState.js',
- './localFile'
+ './workingState.js'
 ]
 .map(require);
 
@@ -46,6 +45,8 @@ describe('API tests', function() {
     var driver;
 
     driver = createDriver(DRIVER, REPO, TOKEN, HOST);
+
+    require('./api/local')(driver);
 
     require('./api/driver')(driver);
 

--- a/test/api/local.js
+++ b/test/api/local.js
@@ -4,27 +4,23 @@ var should = require('should');
 var fs = require('fs');
 var path = require('path');
 var Immutable = require('immutable');
-var LocalFile = require('../lib/models/localFile');
-var RepositoryState = require('../lib/models/repositoryState');
+var LocalFile = require('../../lib/models/localFile');
+var RepositoryState = require('../../lib/models/repositoryState');
 
-var repofs = require('../');
-var LocalFileUtils = repofs.LocalFileUtils;
-
-var GitHubDriver = repofs.GitHubDriver;
+var repofs = require('../..');
+var LocalUtils = repofs.LocalUtils;
 
 var REPO_DIR = '.tmp/repo/';
-var REPO = process.env.REPOFS_REPO;
-var HOST = process.env.REPOFS_HOST;
 
-if (process.env.REPOFS_TOKEN) return;
+module.exports = function (driver) {
+    if (process.env.REPOFS_DRIVER !== 'uhub') return;
 
-describe('LocalFileUtils', function() {
-    var driver = new GitHubDriver({
-        repository: REPO,
-        host: HOST
-    });
+    return describe('LocalUtils', testLocal.bind(this, driver));
+};
 
+function testLocal(driver) {
     describe('.status', function() {
+
         before(function () {
             this.initialReadme = fs.readFileSync(path.join(REPO_DIR, 'README.md'), 'utf8');
             fs.writeFileSync(path.join(REPO_DIR, 'README.md'), 'New content');
@@ -41,7 +37,7 @@ describe('LocalFileUtils', function() {
                 currentBranchName: 'master'
             });
 
-            LocalFileUtils.status(repoState, driver)
+            LocalUtils.status(repoState, driver)
                 .then(function (localFiles) {
                     // is an immutable list
                     localFiles.should.be.instanceof(Immutable.List);
@@ -75,4 +71,4 @@ describe('LocalFileUtils', function() {
                 .catch(done);
         });
     });
-});
+};

--- a/test/localFile.js
+++ b/test/localFile.js
@@ -1,0 +1,76 @@
+
+var should = require('should');
+
+var fs = require('fs');
+var path = require('path');
+var Immutable = require('immutable');
+var LocalFile = require('../lib/models/localFile');
+var RepositoryState = require('../lib/models/repositoryState');
+
+var repofs = require('../');
+var LocalFileUtils = repofs.LocalFileUtils;
+
+var GitHubDriver = repofs.GitHubDriver;
+
+var REPO_DIR = '.tmp/repo/';
+var REPO = process.env.REPOFS_REPO;
+var HOST = process.env.REPOFS_HOST;
+
+describe('LocalFileUtils', function() {
+    var driver = new GitHubDriver({
+        repository: REPO,
+        host: HOST
+    });
+
+    describe('.status', function() {
+        before(function () {
+            this.initialReadme = fs.readFileSync(path.join(REPO_DIR, 'README.md'), 'utf8');
+            fs.writeFileSync(path.join(REPO_DIR, 'README.md'), 'New content');
+            fs.writeFileSync(path.join(REPO_DIR, 'readme2.md'), 'New content');
+        });
+
+        after(function () {
+            fs.writeFileSync(path.join(REPO_DIR, 'README.md'), this.initialReadme);
+            fs.unlinkSync(path.join(REPO_DIR, 'readme2.md'));
+        });
+
+        it('should return list of changed files', function(done) {
+            var repoState = new RepositoryState({
+                currentBranchName: 'master'
+            });
+
+            LocalFileUtils.status(repoState, driver)
+                .then(function (localFiles) {
+                    // is an immutable list
+                    localFiles.should.be.instanceof(Immutable.List);
+
+                    // size equals 2
+                    localFiles.size.should.be.equal(2);
+
+                    // instance of file are LocalFile
+                    localFiles.get(0).should.be.instanceof(LocalFile);
+                    localFiles.get(1).should.be.instanceof(LocalFile);
+
+                    // Content should be consistant
+                    localFiles.get(1).should.eql(LocalFile.create({
+                        sha: '0000000000000000000000000000000000000000',
+                        filename: 'readme2.md',
+                        status: 'untracked',
+                        additions: 0,
+                        deletions: 0,
+                        changes: 0,
+                        patch: ''
+                    }));
+
+                    localFiles.get(0).get('filename').should.equal('README.md');
+                    localFiles.get(0).get('status').should.equal('modified');
+                    localFiles.get(0).get('additions').should.equal(1);
+                    localFiles.get(0).get('deletions').should.equal(1);
+                    localFiles.get(0).get('changes').should.equal(2);
+                    localFiles.get(0).get('patch').should.equal('@@ -1 +1 @@\n-# \\n\n+New content\n\\ No newline at end of file\n');
+                })
+                .then(done)
+                .catch(done);
+        });
+    });
+});

--- a/test/localFile.js
+++ b/test/localFile.js
@@ -16,6 +16,8 @@ var REPO_DIR = '.tmp/repo/';
 var REPO = process.env.REPOFS_REPO;
 var HOST = process.env.REPOFS_HOST;
 
+if (process.env.REPOFS_TOKEN) return;
+
 describe('LocalFileUtils', function() {
     var driver = new GitHubDriver({
         repository: REPO,


### PR DESCRIPTION
Hi!

This PR introduces new APIs to the driver, a new utility called `LocalFileUtils` and a new model `LocalFile`.

It also update the uhub version we are using in tests to match 2.5.1 which includes the needed API to fetch the repository status.