### PR TITLE
Add BranchUtils.update

### DIFF
--- a/lib/models/repositoryState.js
+++ b/lib/models/repositoryState.js
@@ -1,6 +1,7 @@
 var _ = require('lodash');
 var Immutable = require('immutable');
 
+var Normalize = require('../utils/normalize');
 var WorkingState = require('./workingState');
 var Branch = require('./branch');
 var Cache = require('./cache');
@@ -114,13 +115,15 @@ RepositoryState.prototype.isFetched = function(branch) {
 };
 
 /**
- * @param {Branch} branch Branch to update
+ * @param {Branch | String} branchName Branch to update
  * @param {Branch | Null} value New branch value, null to delete
  */
-RepositoryState.prototype.updateBranch = function (branch, value) {
+RepositoryState.prototype.updateBranch = function (branchName, value) {
+    branchName = Normalize.branchName(branchName);
+
     var branches = this.getBranches();
     var index = branches.findIndex(function (br) {
-        return br.getFullName() === branch.getFullName();
+        return br.getFullName() === branchName;
     });
     if (value === null) {
         // Delete

--- a/lib/models/repositoryState.js
+++ b/lib/models/repositoryState.js
@@ -122,8 +122,8 @@ RepositoryState.prototype.updateBranch = function (branchName, value) {
     branchName = Normalize.branchName(branchName);
 
     var branches = this.getBranches();
-    var index = branches.findIndex(function (br) {
-        return br.getFullName() === branchName;
+    var index = branches.findIndex(function (branch) {
+        return branch.getFullName() === branchName;
     });
     if (value === null) {
         // Delete

--- a/lib/utils/branches.js
+++ b/lib/utils/branches.js
@@ -1,5 +1,6 @@
 var _ = require('lodash');
 
+var Normalize = require('./normalize');
 var RepoUtils = require('./repo');
 
 /**
@@ -46,6 +47,31 @@ function create(repoState, driver, name, opts) {
             return RepoUtils.checkout(repoState, createdBranch);
         });
     }
+}
+
+/**
+ * Fetch the list of branches, and update the given branch only. Will update
+ * the WorkingState of the branch (and discard previous
+ * @param {RepositoryState} repoState
+ * @param {Driver} driver
+ * @param {Branch | String} branchName The branch to update
+ * @return {Promise<RepositoryState>} with the branch updated
+ */
+function update(repoState, driver, branchName) {
+    branchName = Normalize.branchName(branchName || repoState.getCurrentBranch());
+
+    return driver.fetchBranches()
+    .then(function (branches) {
+        var newBranch = branches.find(function (b) {
+            return b.getFullName() === branchName;
+        });
+
+        if (!newBranch) {
+            return repoState;
+        } else {
+            return RepoUtils.fetchTree(repoState, driver, newBranch);
+        }
+    });
 }
 
 /**
@@ -106,6 +132,7 @@ function merge(repoState, driver, from, into, options) {
 var BranchUtils = {
     remove: remove,
     create: create,
+    update: update,
     merge: merge
 };
 module.exports = BranchUtils;

--- a/lib/utils/branches.js
+++ b/lib/utils/branches.js
@@ -62,8 +62,8 @@ function update(repoState, driver, branchName) {
 
     return driver.fetchBranches()
     .then(function (branches) {
-        var newBranch = branches.find(function (b) {
-            return b.getFullName() === branchName;
+        var newBranch = branches.find(function (branch) {
+            return branch.getFullName() === branchName;
         });
 
         if (!newBranch) {

--- a/lib/utils/normalize.js
+++ b/lib/utils/normalize.js
@@ -1,0 +1,19 @@
+/**
+ * A set of utilities to coerce arguments.
+ */
+
+
+/**
+ * @param {Branch | String}
+ * @return {String} The branch fullname
+ */
+function branchName(branch) {
+    return typeof branch === 'string'
+        ? branch
+        : branch.getFullName();
+}
+
+module.exports = {
+    branchName: branchName
+};
+

--- a/lib/utils/repo.js
+++ b/lib/utils/repo.js
@@ -70,7 +70,7 @@ function checkout(repoState, branch) {
 }
 
 /**
- * Fetch the list of branches in the repository. Will clear the
+ * Fetch the list of branches in the repository and update them all. Will clear the
  * WorkingStates of all branches that have updated.
  * @param {RepositoryState} repoState
  * @param {Driver} driver
@@ -97,6 +97,7 @@ function fetchBranches(repoState, driver) {
         }, repoState);
     });
 }
+
 /**
  * Initialize a new RepositoryState from the repo of a Driver. Fetch
  * the branches, and checkout master or the first available branch.

--- a/test/api/branch.js
+++ b/test/api/branch.js
@@ -126,6 +126,28 @@ function testBranch(driver) {
         });
     });
 
+    describe('.update', function() {
+        it('should update an old branch that was updated on the repo', function () {
+            var oldBranchState;
+            var updatedBranch;
+
+            return repofs.BranchUtils.create(repoState, driver, 'test-branch-update', {
+                checkout: true
+            })
+            .then(function (_repoState) {
+                oldBranchState = _repoState;
+                return commitAndFlush(_repoState, driver, 'New commit');
+            })
+            .then(function (_repoState) {
+                updatedBranch = _repoState.getCurrentBranch();
+                return repofs.BranchUtils.update(oldBranchState, driver, 'test-branch-update');
+            })
+            .then(function (_repoState) {
+                Immutable.is(updatedBranch, _repoState.getCurrentBranch()).should.be.true();
+            });
+        });
+    });
+
     describe('.remove', function() {
         // Depends on previous
         it('should delete a branch', function () {


### PR DESCRIPTION
This PR adds a `BranchUtils.update` function that fetches a branch, updates its SHA, and updates its WorkingState with the new tree. It won't touch any of the other branches.