### PR TITLE
Use HTTPS for gravatar

### DIFF
--- a/lib/utils/gravatar.js
+++ b/lib/utils/gravatar.js
@@ -2,7 +2,7 @@ var md5Hex = require('md5-hex');
 
 // Get gravatar url
 function gravatarUrl(email) {
-    return 'http://www.gravatar.com/avatar/'+md5Hex(email)+'?s=200&d='+encodeURIComponent('https://www.gitbook.com/assets/images/avatars/user.png');
+    return 'https://www.gravatar.com/avatar/'+md5Hex(email)+'?s=200&d='+encodeURIComponent('https://www.gitbook.com/assets/images/avatars/user.png');
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes mixed content browser warnings/errors
Zendesk ticket: https://gitbook.zendesk.com/agent/tickets/4646