### PR TITLE
Add sync method to RemoteUtils 

### DIFF
--- a/scripts/test-uhub.sh
+++ b/scripts/test-uhub.sh
@@ -30,7 +30,6 @@ function initRepo() {
     git add README.md
     git commit -m "Initial commit"
     git remote add origin $REMOTE_PATH
-    git remote add test $REMOTE_PATH
     cd -
 }
 initRepo >/dev/null

--- a/scripts/test-uhub.sh
+++ b/scripts/test-uhub.sh
@@ -8,8 +8,20 @@ echo "Prepare tests for uhub"
 
 # Create temporary repository for uhub
 REPO_PATH=$(pwd)/.tmp/repo/
+REMOTE_PATH=$(pwd)/.tmp/repo-remote.git/
 rm -rf $REPO_PATH
 mkdir -p $REPO_PATH
+rm -rf $REMOTE_PATH
+mkdir -p $REMOTE_PATH
+
+# Initialize the remote
+function initRemote() {
+    cd $REMOTE_PATH
+    git --bare init .
+    cd -
+}
+initRemote >/dev/null
+
 # Initialize the repo like GitHub
 function initRepo() {
     cd $REPO_PATH
@@ -17,6 +29,8 @@ function initRepo() {
     echo "# Uhub test repository\n" > README.md
     git add README.md
     git commit -m "Initial commit"
+    git remote add origin $REMOTE_PATH
+    git remote add test $REMOTE_PATH
     cd -
 }
 initRepo >/dev/null
@@ -27,6 +41,7 @@ UHUBPID=$!
 function cleanUp() {
     kill -s 9 $UHUBPID
     rm -rf $REPO_PATH
+    rm -rf $REMOTE_PATH
 }
 # Cleanup on exit
 trap cleanUp EXIT

--- a/src/constants/errors.js
+++ b/src/constants/errors.js
@@ -8,7 +8,8 @@ const ERRORS = {
     CONFLICT:              '409 Conflict',
     UNKNOWN_REMOTE:        '404 Unknown Remote',
     AUTHENTICATION_FAILED: '401 Authentication Failed',
-    BLOB_TOO_BIG:          '507 Blog too large'
+    BLOB_TOO_BIG:          '507 Blog too large',
+    REF_NOT_FOUND:         '404 Reference not found'
 };
 // TODO drop HTTP codes completely, for more reliable error checking (no collision)
 

--- a/src/drivers/driver.js
+++ b/src/drivers/driver.js
@@ -135,6 +135,7 @@ class Driver {
      * @throws {Promise<ERROR.NOT_FAST_FORWARD>}
      * @throws {Promise<ERROR.AUTHENTICATION_FAILED>}
      * @throws {Promise<ERROR.UNKNOWN_REMOTE>}
+     * @throws {Promise<ERROR.REF_NOT_FOUND>}
      */
     pull(opts) {}
 

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -280,7 +280,8 @@ class GitHubDriver extends Driver {
         return this.post('pull', opts)
         .fail(normNotFF)
         .fail(normAuth)
-        .fail(normUnknownRemote);
+        .fail(normUnknownRemote)
+        .fail(normRefNotFound);
     }
 
     push(opts) {
@@ -447,6 +448,14 @@ function normUnknownRemote(err) {
     return Q.reject(err);
 }
 
+function normRefNotFound(err) {
+    const msg = err.message;
+    if (/^Reference/.test(msg) && /not found$/.test(msg)) {
+        err.code = ERRORS.REF_NOT_FOUND;
+    }
+
+    return Q.reject(err);
+}
 
 /**
  * Normalize a commit coming from the GitHub commit creation API

--- a/src/utils/remote.js
+++ b/src/utils/remote.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const Q = require('q');
+const Promise = require('q');
 const ERRORS = require('../constants/errors');
 const RepoUtils = require('./repo');
 
@@ -116,25 +116,16 @@ function sync(repoState, driver, opts) {
     });
 
     return pull(repoState, driver, opts)
-        .fail(normRefNotFound)
         .fail((err) => {
             if (err.code === ERRORS.REF_NOT_FOUND) {
-                return Q(repoState);
+                return Promise(repoState);
             }
 
-            return Q.reject(err);
+            return Promise.reject(err);
         })
         .then((newRepoState) => {
             return push(newRepoState, driver, opts);
         });
-}
-
-function normRefNotFound(err) {
-    const msg = err.message;
-    if (/^Reference/.test(msg) && /not found$/.test(msg)) {
-        err.code = ERRORS.REF_NOT_FOUND;
-    }
-    return Q.reject(err);
 }
 
 const RemoteUtils = {

--- a/test/remote.js
+++ b/test/remote.js
@@ -1,4 +1,5 @@
-const should = require('should');
+require('should');
+
 const path = require('path');
 
 const repofs = require('../src/');
@@ -14,7 +15,7 @@ const mock = require('./mock');
 describe('RemoteUtils', function() {
     if (process.env.REPOFS_DRIVER !== 'uhub') return;
 
-    let DEFAULT_BOOK = mock.DEFAULT_BOOK;
+    const DEFAULT_BOOK = mock.DEFAULT_BOOK;
 
     const driver = new GitHubDriver({
         repository: REPO,
@@ -28,7 +29,10 @@ describe('RemoteUtils', function() {
         });
 
         it('should push remote repository', (done) => {
-            RemoteUtils.push(DEFAULT_BOOK, driver)
+            RemoteUtils.edit(driver, 'origin', REMOTE_PATH)
+                .then(() => {
+                    return RemoteUtils.push(DEFAULT_BOOK, driver);
+                })
                 .then((repoState) => {
                     done();
                 })

--- a/test/remote.js
+++ b/test/remote.js
@@ -1,0 +1,138 @@
+const should = require('should');
+const path = require('path');
+
+const repofs = require('../src/');
+const { RemoteUtils, BranchUtils, GitHubDriver } = repofs;
+
+const REPO = process.env.REPOFS_REPO;
+const HOST = process.env.REPOFS_HOST;
+const TOKEN = process.env.REPOFS_TOKEN;
+const REMOTE_PATH = path.resolve('.tmp/repo-remote.git') + '/';
+
+const mock = require('./mock');
+
+describe('RemoteUtils', function() {
+    if (process.env.REPOFS_DRIVER !== 'uhub') return;
+
+    let DEFAULT_BOOK = mock.DEFAULT_BOOK;
+
+    const driver = new GitHubDriver({
+        repository: REPO,
+        host: HOST,
+        token: TOKEN
+    });
+
+    describe('.push', () => {
+        it('should be a function', () => {
+            RemoteUtils.push.should.be.a.Function();
+        });
+
+        it('should push remote repository', (done) => {
+            RemoteUtils.push(DEFAULT_BOOK, driver)
+                .then((repoState) => {
+                    done();
+                })
+                .catch(done);
+        });
+    });
+
+    describe('.pull', () => {
+        it('should be a function', () => {
+            RemoteUtils.pull.should.be.a.Function();
+        });
+
+        it('should pull remote repository', (done) => {
+            RemoteUtils.pull(DEFAULT_BOOK, driver)
+                .then(() => {
+                    done();
+                });
+        });
+    });
+
+    describe('.list', () => {
+        it('should be a function', () => {
+            RemoteUtils.list.should.be.a.Function();
+        });
+
+        it('should list remotes', (done) => {
+            RemoteUtils.list(driver)
+                .then((remotes) => {
+                    remotes.should.be.an.instanceOf(Array);
+                    remotes[0].should.have.property('name');
+                    remotes[0].should.have.property('url');
+                    remotes[0].name.should.equal('origin');
+                    remotes[0].url.should.equal(REMOTE_PATH);
+                    done();
+                })
+                .catch(done);
+        });
+    });
+
+    describe('.edit', () => {
+        it('should be a function', () => {
+            RemoteUtils.edit.should.be.a.Function();
+        });
+
+        it('should edit remotes', (done) => {
+            RemoteUtils.edit(driver, 'origin', 'foobar')
+                .then(() => {
+                    return RemoteUtils.list(driver);
+                })
+                .then((remotes) => {
+                    remotes[0].name.should.equal('origin');
+                    remotes[0].url.should.equal('foobar');
+                })
+                // reset remote to its original path
+                .then(() => {
+                    return RemoteUtils.edit(driver, 'origin', REMOTE_PATH);
+                })
+                .then(() => {
+                    return RemoteUtils.list(driver);
+                })
+                .then((remotes) => {
+                    remotes[0].name.should.equal('origin');
+                    remotes[0].url.should.equal(REMOTE_PATH);
+                })
+                .then(done)
+                .catch(done);
+        });
+    });
+
+    describe('.sync', () => {
+        let repoState;
+
+        before(function() {
+            return repofs.RepoUtils.initialize(driver)
+            .then(function(initRepo) {
+                repoState = initRepo;
+            });
+        });
+
+        it('should be a function', () => {
+            RemoteUtils.sync.should.be.a.Function();
+        });
+
+        it('should sync to remote test-remote branch name', (done) => {
+            BranchUtils.create(repoState, driver, 'test-remote', {})
+                .then((newRepoState) => {
+                    newRepoState = newRepoState.set('currentBranchName', 'test-remote');
+                    return RemoteUtils.sync(newRepoState, driver);
+                })
+                .then((newRepoState) => {
+                    newRepoState.currentBranchName.should.equal('test-remote');
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('should sync to remote master branch name which exists', (done) => {
+            RemoteUtils.sync(repoState, driver)
+                .then((newRepoState) => {
+                    newRepoState.currentBranchName.should.equal('master');
+                    done();
+                })
+                .catch(done);
+        });
+    });
+
+});


### PR DESCRIPTION
This tries to pull followed by a push on a remote repository. When the
remote branch reference doesn't exists, the error is normalized using
`ERRORS.REF_NOT_FOUND`, which results in the error being ignored to
follow by a push.

Tests have been added as well to test the remaining of the RemoteUtils
methods (push, pull, list, edit).