### PR TITLE
Update uhub to 3.1.0

### DIFF
--- a/scripts/download-uhub.sh
+++ b/scripts/download-uhub.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 IFS=$'\n\t'
 
-UHUB_VERSION=2.7.0
+UHUB_VERSION=3.1.0
 
 # Download Uhub
 if [ "$(uname)" == "Darwin" ]; then

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -254,17 +254,17 @@ class GitHubDriver extends Driver {
 
     // ---- Only supported by uhub ----
     checkout(branch) {
-        return this.post('checkout', {
+        return this.post('local/checkout', {
             branch: branch ? branch.getFullName() : 'HEAD'
         });
     }
 
     listRemotes() {
-        return this.get('remotes');
+        return this.get('local/remotes');
     }
 
     editRemotes(name, url) {
-        return this.post('remotes', {
+        return this.post('local/remotes', {
             name,
             url
         });
@@ -277,7 +277,7 @@ class GitHubDriver extends Driver {
         // Convert to ref
         opts.branch = opts.branch.getName();
 
-        return this.post('pull', opts)
+        return this.post('local/pull', opts)
         .fail(normNotFF)
         .fail(normAuth)
         .fail(normUnknownRemote)
@@ -291,14 +291,14 @@ class GitHubDriver extends Driver {
         // Convert to ref
         opts.branch = opts.branch.getName();
 
-        return this.post('push', opts)
+        return this.post('local/push', opts)
         .fail(normNotFF)
         .fail(normAuth)
         .fail(normUnknownRemote);
     }
 
     status(opts) {
-        return this.get('status')
+        return this.get('local/status')
             .then(function(status) {
                 return {
                     files: new List(status.files).map(function(file) {
@@ -340,7 +340,7 @@ class GitHubDriver extends Driver {
             };
         }
 
-        return this.post('track', params);
+        return this.post('local/track', params);
     }
 
     // API utilities


### PR DESCRIPTION
This PR updates uhub to latest version 3.1.0 which includes one breaking change: local api methods are now prefixed by `/local/`.

This PR updates the driver to make the tests pass.