### PR TITLE
Handling git submodules

### DIFF
--- a/scripts/download-uhub.sh
+++ b/scripts/download-uhub.sh
@@ -4,6 +4,8 @@ IFS=$'\n\t'
 
 UHUB_VERSION=3.1.0
 
+echo "Downloading uhub..."
+
 # Download Uhub
 if [ "$(uname)" == "Darwin" ]; then
     UHUB_NAME=uhub_darwin_amd64
@@ -15,10 +17,8 @@ fi
 
 if [ -f uhub ];
 then
-    echo "uhub already exist."
+    echo "uhub already downloaded."
 else
-    echo "Downloading uhub"
-
     if [[ -z "$GITHUB_TOKEN" ]]; then
         cat <<EOF
 To download uhub, you need to provide the following env:

--- a/scripts/download-uhub.sh
+++ b/scripts/download-uhub.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 IFS=$'\n\t'
 
-UHUB_VERSION=3.1.0
+UHUB_VERSION=3.1.2
 
 echo "Downloading uhub..."
 

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -65,9 +65,12 @@ class GitHubDriver extends Driver {
             const treeEntries = new Map().withMutations(
                 function addEntries(map) {
                     tree.tree.map((entry) => {
+                        // We ignore trees for now (we flatten the git tree)
                         if (entry.type === 'tree') return;
+
                         const treeEntry = new TreeEntry({
                             sha: entry.sha,
+                            type: entry.type,
                             blobSize: entry.size,
                             mode: entry.mode
                         });
@@ -127,7 +130,7 @@ class GitHubDriver extends Driver {
                 return {
                     path: filePath,
                     mode: treeEntry.getMode(),
-                    type: 'blob',
+                    type: treeEntry.getType(),
                     sha: blobSHAs[filePath] || treeEntry.getSha()
                 };
             }).toArray();

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const GitHubDriver = require('./drivers/github');
 
 const RepositoryState = require('./models/repositoryState');
 const WorkingState = require('./models/workingState');
+const TreeEntry = require('./models/treeEntry');
 const Author = require('./models/author');
 const Branch = require('./models/branch');
 const CommitBuilder = require('./models/commitBuilder');
@@ -34,6 +35,7 @@ module.exports = {
     // Models
     RepositoryState,
     WorkingState,
+    TreeEntry,
     File,
     Blob,
     Author,

--- a/src/models/treeEntry.js
+++ b/src/models/treeEntry.js
@@ -1,11 +1,20 @@
 const { Record } = require('immutable');
 
+const TYPES = {
+    BLOB: 'blob',
+    // tree: 'tree', we don't yet support this one
+    COMMIT: 'commit'
+};
+
 const DEFAULTS = {
     // SHA of the corresponding blob
     sha: null, // String, null when content is not available as blob
 
     // Mode of the file
     mode: '100644',
+
+    // Can be a 'tree', 'commit', or 'blob'
+    type: TYPES.BLOB,
 
     // Size of the blob
     blobSize: 0
@@ -17,21 +26,24 @@ const DEFAULTS = {
  */
 class TreeEntry extends Record(DEFAULTS) {
     // ---- Properties Getter ----
-
-    getSha() {
-        return this.get('sha');
-    }
-
-    hasSha() {
-        return this.getSha() !== null;
+    getBlobSize() {
+        return this.get('blobSize');
     }
 
     getMode() {
         return this.get('mode');
     }
 
-    getBlobSize() {
-        return this.get('blobSize');
+    getSha() {
+        return this.get('sha');
+    }
+
+    getType() {
+        return this.get('type');
+    }
+
+    hasSha() {
+        return this.getSha() !== null;
     }
 }
 
@@ -40,6 +52,7 @@ class TreeEntry extends Record(DEFAULTS) {
 TreeEntry.encode = function(treeEntry) {
     return {
         sha: treeEntry.getSha(),
+        type: treeEntry.getType(),
         mode: treeEntry.getMode(),
         size: treeEntry.getBlobSize()
     };
@@ -48,9 +61,12 @@ TreeEntry.encode = function(treeEntry) {
 TreeEntry.decode = function(json) {
     return new TreeEntry({
         sha: json.sha,
+        type: json.type,
         mode: json.mode,
         blobSize: json.size
     });
 };
+
+TreeEntry.TYPES = TYPES;
 
 module.exports = TreeEntry;

--- a/src/utils/directory.js
+++ b/src/utils/directory.js
@@ -4,13 +4,14 @@ const uniqueBy = require('unique-by');
 
 const FILETYPE = require('../constants/filetype');
 const File = require('../models/file');
+const TreeEntry = require('../models/treeEntry');
 
 const PathUtils = require('./path');
 const WorkingUtils = require('./working');
 const FileUtils = require('./file');
 
 /**
- * List entries in a directory (shallow)
+ * List files in a directory (shallow)
  * @param {RepositoryState} repoState
  * @param {Path} dirName
  * @return {Array<File>}
@@ -25,6 +26,8 @@ function read(repoState, dirName) {
     const files = [];
 
     treeEntries.forEach(function(treeEntry, filepath) {
+        // Ignore git submodules
+        if (treeEntry.getType() !== TreeEntry.TYPES.BLOB) return;
         if (!PathUtils.contains(dirName, filepath)) return;
 
         const innerPath = PathUtils.norm(filepath.replace(dirName, ''));

--- a/src/utils/working.js
+++ b/src/utils/working.js
@@ -10,12 +10,15 @@ const CHANGES = require('../constants/changeType');
  * @return {Set<Path>}
  */
 function getMergedFileSet(workingState) {
-    return Immutable.Set.fromKeys(getMergedTreeEntries(workingState));
+    return Immutable.Set.fromKeys(
+        getMergedTreeEntries(workingState).filter(
+            treeEntry => treeEntry.getType() === TreeEntry.TYPES.BLOB
+        )
+    );
 }
 
 /**
  * Returns a Map of TreeEntry, with sha null when the content is not available as sha.
- * The size of the TreeEntries
  * @param {WorkingState}
  * @return {Map<TreeEntries>}
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,6 +84,10 @@ arr-flatten@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz#e5ffe54d45e19f32f216e91eb99c8ce892bb604b"
 
+array-flatten@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.0.tgz#26a692c83881fc68dac3ec5d1f0c1b49bf2304d9"
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -1616,6 +1620,10 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
+is@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/is/-/is-3.2.0.tgz#a362e3daf7df3fd8b7114115d624c5b7e1cb90f7"
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -1856,6 +1864,10 @@ mocha@2.4.5:
     jade "0.26.3"
     mkdirp "0.5.1"
     supports-color "1.2.0"
+
+modify-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.0.tgz#e2b6cdeb9ce19f99317a53722f3dbf5df5eaaab2"
 
 ms@0.7.1:
   version "0.7.1"
@@ -2517,6 +2529,10 @@ underscore.string@~2.4.0:
 underscore@~1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
+
+unique-by@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-by/-/unique-by-1.0.0.tgz#5220c86ba7bc572fb713ad74651470cb644212bd"
 
 urljoin.js@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Committing from a git tree that contains submodules was failing (because it would corrupt git submodules tree entries).

This fixes that.

Related to https://github.com/GitbookIO/gitbook/issues/1629

