### PR TITLE
Add method Repofs.Commit.fetchCompare

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "array-flatten": "^2.1.0",
     "axios": "^0.8.0",
-    "eslint-config-gitbook": "^1.4.0",
+    "eslint-config-gitbook": "1.5.0",
     "immutable": "^3.7.6",
     "is": "^3.2.0",
     "md5-hex": "^1.1.0",
@@ -23,12 +23,12 @@
     "urljoin.js": "^0.1.0"
   },
   "devDependencies": {
-    "lodash": "^4.13.1",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
     "babel-preset-es2015": "^6.18.0",
     "eslint": "^3.1.1",
     "github-releases": "0.3.2",
+    "lodash": "^4.13.1",
     "mocha": "2.4.5",
     "should": "8.2.2"
   },

--- a/src/drivers/driver.js
+++ b/src/drivers/driver.js
@@ -49,7 +49,10 @@ class Driver {
      * @param {Ref} ref2
      * @return {Promise<Commit | Null>}
      */
-    findParentCommit(ref1, ref2) {}
+    findParentCommit(ref1, ref2) {
+        return this.compare(ref1, ref2)
+        .then(compare => compare.closest.sha ? compare.closest : null);
+    }
 
     /**
      * List all the commits reachable from head, but not from base. Most
@@ -58,7 +61,18 @@ class Driver {
      * @param {Branch | SHA} head
      * @return {Promise<List<Commit>>}
      */
-    fetchOwnCommits(base, head) {}
+    fetchOwnCommits(base, head) {
+        return this.compare(base, head)
+        .then(compare => compare.commits);
+    }
+
+    /**
+     * Compare two commits.
+     * @param {Branch | SHA} base
+     * @param {Branch | SHA} head
+     * @return {Promise<Compare>}
+     */
+    compare(base, head) {}
 
     /**
      * Update a branch forward to a given commit

--- a/src/drivers/driver.js
+++ b/src/drivers/driver.js
@@ -50,7 +50,7 @@ class Driver {
      * @return {Promise<Commit | Null>}
      */
     findParentCommit(ref1, ref2) {
-        return this.fetchCompare(ref1, ref2)
+        return this.fetchComparison(ref1, ref2)
         .then(compare => compare.closest.sha ? compare.closest : null);
     }
 
@@ -62,7 +62,7 @@ class Driver {
      * @return {Promise<List<Commit>>}
      */
     fetchOwnCommits(base, head) {
-        return this.fetchCompare(base, head)
+        return this.fetchComparison(base, head)
         .then(compare => compare.commits);
     }
 
@@ -70,9 +70,9 @@ class Driver {
      * Compare two commits.
      * @param {Branch | SHA} base
      * @param {Branch | SHA} head
-     * @return {Promise<Compare>}
+     * @return {Promise<Comparison>}
      */
-    fetchCompare(base, head) {}
+    fetchComparison(base, head) {}
 
     /**
      * Update a branch forward to a given commit

--- a/src/drivers/driver.js
+++ b/src/drivers/driver.js
@@ -50,7 +50,7 @@ class Driver {
      * @return {Promise<Commit | Null>}
      */
     findParentCommit(ref1, ref2) {
-        return this.compare(ref1, ref2)
+        return this.fetchCompare(ref1, ref2)
         .then(compare => compare.closest.sha ? compare.closest : null);
     }
 
@@ -62,7 +62,7 @@ class Driver {
      * @return {Promise<List<Commit>>}
      */
     fetchOwnCommits(base, head) {
-        return this.compare(base, head)
+        return this.fetchCompare(base, head)
         .then(compare => compare.commits);
     }
 
@@ -72,7 +72,7 @@ class Driver {
      * @param {Branch | SHA} head
      * @return {Promise<Compare>}
      */
-    compare(base, head) {}
+    fetchCompare(base, head) {}
 
     /**
      * Update a branch forward to a given commit

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -200,7 +200,7 @@ class GitHubDriver extends Driver {
             return Compare.create({
                 commits: res.commits.map(normListedCommit),
                 files: res.files,
-                closest: normListedCommit(res.base_commit),
+                closest: normListedCommit(res.merge_base_commit),
                 base,
                 head
             });

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -51,7 +51,7 @@ class GitHubDriver extends Driver {
 
     fetchBlob(sha) {
         return this.get('git/blobs/' + sha)
-        .then(function(r) {
+        .then((r) => {
             return Blob.createFromBase64(r.content);
         });
     }
@@ -61,7 +61,7 @@ class GitHubDriver extends Driver {
         return this.get('git/trees/' + ref, {
             recursive: 1
         })
-        .then(function(tree) {
+        .then((tree) => {
             const treeEntries = new Map().withMutations(
                 function addEntries(map) {
                     tree.tree.map((entry) => {
@@ -84,7 +84,7 @@ class GitHubDriver extends Driver {
 
     fetchBranches() {
         return this.get('branches')
-        .then(function(branches) {
+        .then((branches) => {
             branches = branches.map((branch) => {
                 // TODO properly detect remote
                 return new Branch({
@@ -105,19 +105,19 @@ class GitHubDriver extends Driver {
         const that = this;
 
         // Create blobs required
-        const blobPromises = commitBuilder.getBlobs().map(function(blob, filePath) {
+        const blobPromises = commitBuilder.getBlobs().map((blob, filePath) => {
             return that.post('git/blobs', {
                 content: blob.getAsBase64(),
                 encoding: 'base64'
             })
-            .then(function(ghBlob) {
+            .then((ghBlob) => {
                 return [filePath, ghBlob.sha];
             });
         });
 
         // Wait for all request to finish
         return Q.all(blobPromises.toArray())
-        .then(function(result) {
+        .then((result) => {
             // Recreate an object map from the list of [path, sha]
             return result.reduce((res, [key, value]) => {
                 res[key] = value;
@@ -125,8 +125,8 @@ class GitHubDriver extends Driver {
             }, {});
         })
         // Create new tree
-        .then(function(blobSHAs) {
-            const entries = commitBuilder.getTreeEntries().map(function(treeEntry, filePath) {
+        .then((blobSHAs) => {
+            const entries = commitBuilder.getTreeEntries().map((treeEntry, filePath) => {
                 return {
                     path: filePath,
                     mode: treeEntry.getMode(),
@@ -140,7 +140,7 @@ class GitHubDriver extends Driver {
         })
 
         // Create the new commit
-        .then(function(ghTree) {
+        .then((ghTree) => {
             const committer = commitBuilder.getCommitter();
             const author = commitBuilder.getAuthor();
             const payload = {
@@ -172,7 +172,7 @@ class GitHubDriver extends Driver {
         };
 
         return this.get('commits', apiOpts)
-        .then(function(commits) {
+        .then((commits) => {
             return new List(commits).map(normListedCommit);
         });
     }
@@ -186,7 +186,7 @@ class GitHubDriver extends Driver {
     // https://developer.github.com/v3/repos/commits/#compare-two-commits
     findParentCommit(ref1, ref2) {
         return this.get('compare/' + ref1 + '...' + ref2)
-        .then(function(res) {
+        .then((res) => {
             const commit = res.merge_base_commit;
             if (!commit || !commit.sha) {
                 return null;
@@ -198,12 +198,12 @@ class GitHubDriver extends Driver {
 
     // https://developer.github.com/v3/repos/commits/#compare-two-commits
     fetchOwnCommits(base, head) {
-        const refs = [base, head].map(function(x) {
+        const refs = [base, head].map((x) => {
             return (x instanceof Branch) ? x.getFullName() : x;
         });
 
         return this.get('compare/' + refs[0] + '...' + refs[1])
-        .then(function(res) {
+        .then((res) => {
             return new List(res.commits).map(normListedCommit);
         });
     }
@@ -244,7 +244,7 @@ class GitHubDriver extends Driver {
             head,
             commit_message: opts.message
         })
-        .then(function(ghCommit) {
+        .then((ghCommit) => {
             if (!ghCommit) {
                 // No commit was needed
                 return null;
@@ -306,9 +306,9 @@ class GitHubDriver extends Driver {
 
     status(opts) {
         return this.get('local/status')
-            .then(function(status) {
+            .then((status) => {
                 return {
-                    files: new List(status.files).map(function(file) {
+                    files: new List(status.files).map((file) => {
                         return LocalFile.create(file);
                     }),
 
@@ -323,7 +323,7 @@ class GitHubDriver extends Driver {
     track(opts) {
         const params = {
             message: opts.message,
-            files: opts.files.map(function(file) {
+            files: opts.files.map((file) => {
                 return {
                     name: file.getFilename(),
                     status: file.getStatus()
@@ -386,7 +386,7 @@ class GitHubDriver extends Driver {
         // console.log('API', httpMethod.toUpperCase(), method);
         return Q(axios(axiosOpts))
         .get('data')
-        .fail(function(response) {
+        .fail((response) => {
             if (response instanceof Error) throw response;
 
             const e = new Error(response.data.message || 'Error ' + response.status + ': ' + response.data);

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -190,7 +190,7 @@ class GitHubDriver extends Driver {
      * @param {Branch | SHA} head
      * @return {Promise<Compare>}
      */
-    compare(base, head) {
+    fetchCompare(base, head) {
         const refs = [base, head].map((x) => {
             return (x instanceof Branch) ? x.getFullName() : x;
         });

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -16,7 +16,7 @@ const TreeEntry = require('../models/treeEntry');
 const WorkingState = require('../models/workingState');
 const LocalFile = require('../models/localFile');
 const Reference = require('../models/reference');
-const Compare = require('../models/compare');
+const Comparison = require('../models/comparison');
 
 /**
  * Options for the GitHub Driver
@@ -188,16 +188,16 @@ class GitHubDriver extends Driver {
      * Compare two commits.
      * @param {Branch | SHA} base
      * @param {Branch | SHA} head
-     * @return {Promise<Compare>}
+     * @return {Promise<Comparison>}
      */
-    fetchCompare(base, head) {
+    fetchComparison(base, head) {
         const refs = [base, head].map((x) => {
             return (x instanceof Branch) ? x.getFullName() : x;
         });
 
         return this.get('compare/' + refs[0] + '...' + refs[1])
         .then((res) => {
-            return Compare.create({
+            return Comparison.create({
                 commits: res.commits.map(normListedCommit),
                 files: res.files,
                 closest: normListedCommit(res.merge_base_commit),

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -16,7 +16,7 @@ const TreeEntry = require('../models/treeEntry');
 const WorkingState = require('../models/workingState');
 const LocalFile = require('../models/localFile');
 const Reference = require('../models/reference');
-const Compare = require('../models/Compare');
+const Compare = require('../models/compare');
 
 /**
  * Options for the GitHub Driver

--- a/src/drivers/github.js
+++ b/src/drivers/github.js
@@ -16,6 +16,7 @@ const TreeEntry = require('../models/treeEntry');
 const WorkingState = require('../models/workingState');
 const LocalFile = require('../models/localFile');
 const Reference = require('../models/reference');
+const Compare = require('../models/Compare');
 
 /**
  * Options for the GitHub Driver
@@ -183,28 +184,26 @@ class GitHubDriver extends Driver {
         .then(normListedCommit);
     }
 
-    // https://developer.github.com/v3/repos/commits/#compare-two-commits
-    findParentCommit(ref1, ref2) {
-        return this.get('compare/' + ref1 + '...' + ref2)
-        .then((res) => {
-            const commit = res.merge_base_commit;
-            if (!commit || !commit.sha) {
-                return null;
-            } else {
-                return normListedCommit(commit);
-            }
-        });
-    }
-
-    // https://developer.github.com/v3/repos/commits/#compare-two-commits
-    fetchOwnCommits(base, head) {
+    /**
+     * Compare two commits.
+     * @param {Branch | SHA} base
+     * @param {Branch | SHA} head
+     * @return {Promise<Compare>}
+     */
+    compare(base, head) {
         const refs = [base, head].map((x) => {
             return (x instanceof Branch) ? x.getFullName() : x;
         });
 
         return this.get('compare/' + refs[0] + '...' + refs[1])
         .then((res) => {
-            return new List(res.commits).map(normListedCommit);
+            return Compare.create({
+                commits: res.commits.map(normListedCommit),
+                files: res.files,
+                closest: normListedCommit(res.base_commit),
+                base,
+                head
+            });
         });
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ const Conflict = require('./models/conflict');
 const TreeConflict = require('./models/treeConflict');
 const File = require('./models/file');
 const Blob = require('./models/blob');
+const FileDiff = require('./models/fileDiff');
+const Compare = require('./models/compare');
 
 const CHANGE = require('./constants/changeType');
 const ERRORS = require('./constants/errors');
@@ -43,6 +45,8 @@ module.exports = {
     CommitBuilder,
     Conflict,
     TreeConflict,
+    FileDiff,
+    Compare,
 
     // Constants
     CHANGE,

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const TreeConflict = require('./models/treeConflict');
 const File = require('./models/file');
 const Blob = require('./models/blob');
 const FileDiff = require('./models/fileDiff');
-const Compare = require('./models/compare');
+const Comparison = require('./models/comparison');
 
 const CHANGE = require('./constants/changeType');
 const ERRORS = require('./constants/errors');
@@ -46,7 +46,7 @@ module.exports = {
     Conflict,
     TreeConflict,
     FileDiff,
-    Compare,
+    Comparison,
 
     // Constants
     CHANGE,

--- a/src/models/commit.js
+++ b/src/models/commit.js
@@ -1,5 +1,6 @@
 const { Record, List } = require('immutable');
 const Author = require('./author');
+const FileDiff = require('./fileDiff');
 
 /**
  * Represents a Commit in the history (already created)
@@ -15,16 +16,7 @@ const DEFAULTS = {
     // String formatted date of the commit
     date:    String(),
     // List of files modified with their SHA and patch.
-    // File: {
-    //   sha: '...',
-    //   filename: README.md,
-    //   status: modified,
-    //   additions: 2,
-    //   deletions: 0,
-    //   changes: 2,
-    //   patch: ''
-    // }
-    files:   List(), // List<JSON>
+    files:   List(), // List<FileDiff>
     // Parents of the commit (List<SHA>)
     parents: List()
 };
@@ -57,28 +49,30 @@ class Commit extends Record(DEFAULTS) {
     getParents() {
         return this.get('parents');
     }
+
+    /**
+     * @param {SHA} opts.sha
+     * @param {Array<SHA>} opts.parents
+     * @param {String} [opts.message]
+     * @param {String} [opts.date]
+     * @param {Author} [opts.author]
+     * @param {Array<JSON>} [opts.files] Modified files objects, as returned by the GitHub API
+     * @return {Commit}
+     */
+    static create(opts) {
+        if (opts instanceof Commit) {
+            return opts;
+        }
+
+        return new Commit({
+            sha: opts.sha,
+            message: opts.message,
+            author: opts.author,
+            date: opts.date,
+            files: List(opts.files).map(file => FileDiff.create(file)),
+            parents: List(opts.parents)
+        });
+    }
 }
-
-// ---- Statics
-
-/**
- * @param {SHA} opts.sha
- * @param {Array<SHA>} opts.parents
- * @param {String} [opts.message]
- * @param {String} [opts.date]
- * @param {Author} [opts.author]
- * @param {Array<JSON>} [opts.files] Modified files objects, as returned by the GitHub API
- * @return {Commit}
- */
-Commit.create = function(opts) {
-    return new Commit({
-        sha: opts.sha,
-        message: opts.message,
-        author: opts.author,
-        date: opts.date,
-        files: new List(opts.files),
-        parents: new List(opts.parents)
-    });
-};
 
 module.exports = Commit;

--- a/src/models/compare.js
+++ b/src/models/compare.js
@@ -1,0 +1,44 @@
+const { Record, List } = require('immutable');
+const FileDiff = require('./fileDiff');
+const Commit = require('./commit');
+
+/**
+ * Represents a compare in the history.
+ */
+
+const DEFAULTS = {
+    base:    String(),
+    head:    String(),
+    // Closest parent in the compare
+    closest: new Commit(),
+    // List of files modified with their SHA and patch.
+    files:   List(), // List<FileDiff>
+    // List of commits in the range (List<Commit>)
+    commits: List()
+};
+
+/**
+ * @type {Class}
+ */
+class Compare extends Record(DEFAULTS) {
+
+    /**
+     * @return {Commit}
+     */
+    static create(opts) {
+        if (opts instanceof Compare) {
+            return opts;
+        }
+
+        return new Compare({
+            base:    opts.base,
+            head:    opts.head,
+            closest: Commit.create(opts.closest),
+            files:   List(opts.files).map(file => FileDiff.create(file)),
+            commits: List(opts.commits).map(commit => Commit.create(commit))
+        });
+    }
+
+}
+
+module.exports = Compare;

--- a/src/models/comparison.js
+++ b/src/models/comparison.js
@@ -3,7 +3,7 @@ const FileDiff = require('./fileDiff');
 const Commit = require('./commit');
 
 /**
- * Represents a compare in the history.
+ * Represents a comparison in the history.
  */
 
 const DEFAULTS = {
@@ -20,17 +20,17 @@ const DEFAULTS = {
 /**
  * @type {Class}
  */
-class Compare extends Record(DEFAULTS) {
+class Comparison extends Record(DEFAULTS) {
 
     /**
      * @return {Commit}
      */
     static create(opts) {
-        if (opts instanceof Compare) {
+        if (opts instanceof Comparison) {
             return opts;
         }
 
-        return new Compare({
+        return new Comparison({
             base:    opts.base,
             head:    opts.head,
             closest: Commit.create(opts.closest),
@@ -41,4 +41,4 @@ class Compare extends Record(DEFAULTS) {
 
 }
 
-module.exports = Compare;
+module.exports = Comparison;

--- a/src/models/fileDiff.js
+++ b/src/models/fileDiff.js
@@ -1,0 +1,41 @@
+const { Record, List } = require('immutable');
+const Author = require('./author');
+
+/**
+ * Represents a file in a compare.
+ */
+
+const STATUS = {
+    MODIFIED: 'modified',
+    ADDED:    'added',
+    REMOVED:  'removed'
+};
+
+const DEFAULTS = {
+    sha:       String(),
+    filename:  String(),
+    status:    String(STATUS.ADDED),
+    additions: Number(0),
+    deletions: Number(0),
+    changes:   Number(0),
+    patch:     String()
+};
+
+/**
+ * @type {Class}
+ */
+class FileDiff extends Record(DEFAULTS) {
+
+    /**
+     * @return {FileDiff}
+     */
+    static create(opts) {
+        if (opts instanceof FileDiff) {
+            return opts;
+        }
+
+        return new FileDiff(opts);
+    }
+}
+
+module.exports = FileDiff;

--- a/src/models/repositoryState.js
+++ b/src/models/repositoryState.js
@@ -49,7 +49,7 @@ class RepositoryState extends Record(DEFAULTS) {
      */
     getBranch(branchName) {
         const branch = this.getBranches()
-                .find(function(_branch) {
+                .find((_branch) => {
                     return branchName == _branch.getFullName();
                 });
         return branch || null;
@@ -103,7 +103,7 @@ class RepositoryState extends Record(DEFAULTS) {
      * @param {String} fullname Such as 'origin/master' or 'develop'
      */
     hasBranch(fullname) {
-        return this.getBranches().some(function(branch) {
+        return this.getBranches().some((branch) => {
             return branch.getFullName() === fullname;
         });
     }
@@ -124,7 +124,7 @@ class RepositoryState extends Record(DEFAULTS) {
         branchName = Normalize.branchName(branchName);
 
         let branches = this.getBranches();
-        const index = branches.findIndex(function(branch) {
+        const index = branches.findIndex((branch) => {
             return branch.getFullName() === branchName;
         });
         if (value === null) {

--- a/src/utils/blob.js
+++ b/src/utils/blob.js
@@ -28,7 +28,7 @@ function fetch(repoState, driver, sha) {
     // Fetch the blob
     return driver.fetchBlob(sha)
     // Then store it in the cache
-    .then(function(blob) {
+    .then((blob) => {
         const newCache = CacheUtils.addBlob(cache, sha, blob);
         return repoState.set('cache', newCache);
     });

--- a/src/utils/branches.js
+++ b/src/utils/branches.js
@@ -15,7 +15,7 @@ function create(repositoryState, driver, name, opts) {
     let createdBranch;
     const result = driver.createBranch(base, name)
     // Update list of branches
-    .then(function(branch) {
+    .then((branch) => {
         createdBranch = branch;
         let branches = repositoryState.getBranches();
         branches = branches.push(createdBranch);
@@ -41,7 +41,7 @@ function create(repositoryState, driver, name, opts) {
             }
         })
         // Checkout
-        .then(function(repoState) {
+        .then((repoState) => {
             return RepoUtils.checkout(repoState, createdBranch);
         });
     }
@@ -59,8 +59,8 @@ function update(repoState, driver, branchName) {
     branchName = Normalize.branchName(branchName || repoState.getCurrentBranch());
 
     return driver.fetchBranches()
-    .then(function(branches) {
-        const newBranch = branches.find(function(branch) {
+    .then((branches) => {
+        const newBranch = branches.find((branch) => {
             return branch.getFullName() === branchName;
         });
 
@@ -81,7 +81,7 @@ function update(repoState, driver, branchName) {
  */
 function remove(repoState, driver, branch) {
     return driver.deleteBranch(branch)
-    .then(function() {
+    .then(() => {
         return repoState.updateBranch(branch, null);
     });
 }

--- a/src/utils/change.js
+++ b/src/utils/change.js
@@ -93,7 +93,7 @@ function revertForDir(repoState, dirPath) {
     let changes = workingState.getChanges();
 
     // Remove all changes that are in the directory
-    changes = changes.filter(function(change, filePath) {
+    changes = changes.filter((change, filePath) => {
         return !PathUtils.contains(dirPath, filePath);
     });
 
@@ -111,7 +111,7 @@ function revertAllRemoved(repoState) {
     let workingState = repoState.getCurrentState();
     const changes = workingState.getChanges().filter(
         // Remove all changes that are in the directory
-        function(change) {
+        (change) => {
             return change.getType() === CHANGE_TYPE.REMOVE;
         }
     );

--- a/src/utils/commit.js
+++ b/src/utils/commit.js
@@ -30,9 +30,9 @@ function prepare(repoState, opts) {
     opts.treeEntries = WorkingUtils.getMergedTreeEntries(workingState);
 
     // Create map of blobs that needs to be created
-    opts.blobs = changes.filter(function(change) {
+    opts.blobs = changes.filter((change) => {
         return !change.hasSha();
-    }).map(function(change) {
+    }).map((change) => {
         return change.getContent();
     });
 
@@ -68,7 +68,7 @@ function flush(repoState, driver, commitBuilder, options = {}) {
     // Create new commit
     return driver.flushCommit(commitBuilder)
     // Forward the branch
-    .then(function(commit) {
+    .then((commit) => {
         return driver.forwardBranch(options.branch, commit.getSha())
         // Fetch new workingState and replace old one
         .then(function updateBranch() {

--- a/src/utils/commit.js
+++ b/src/utils/commit.js
@@ -137,11 +137,23 @@ function fetch(driver, sha) {
     return driver.fetchCommit(sha);
 }
 
+/**
+ * Compare two commits/branch
+ * @param {Driver} driver
+ * @param {SHA or Branch} base
+ * @param {SHA or Branch} head
+ * @return {Promise<Compare>}
+ */
+function fetchCompare(driver, base, head) {
+    return driver.fetchCompare(base, head);
+}
+
 const CommitUtils = {
     prepare,
     flush,
     fetchList,
     fetchOwnCommits,
-    fetch
+    fetch,
+    fetchCompare
 };
 module.exports = CommitUtils;

--- a/src/utils/commit.js
+++ b/src/utils/commit.js
@@ -142,10 +142,10 @@ function fetch(driver, sha) {
  * @param {Driver} driver
  * @param {SHA or Branch} base
  * @param {SHA or Branch} head
- * @return {Promise<Compare>}
+ * @return {Promise<Comparison>}
  */
-function fetchCompare(driver, base, head) {
-    return driver.fetchCompare(base, head);
+function fetchComparison(driver, base, head) {
+    return driver.fetchComparison(base, head);
 }
 
 const CommitUtils = {
@@ -154,6 +154,6 @@ const CommitUtils = {
     fetchList,
     fetchOwnCommits,
     fetch,
-    fetchCompare
+    fetchComparison
 };
 module.exports = CommitUtils;

--- a/src/utils/conflict.js
+++ b/src/utils/conflict.js
@@ -22,17 +22,17 @@ function compareRefs(driver, base, head) {
     const headRef = head instanceof Branch ? head.getFullName() : head;
 
     return driver.findParentCommit(baseRef, headRef)
-    .then(function(parentCommit) {
+    .then((parentCommit) => {
         // There can be no parent commit
         return Q.all([
             parentCommit ? parentCommit.getSha() : null,
             baseRef,
             headRef
-        ].map(function(ref) {
+        ].map((ref) => {
             return ref ? driver.fetchWorkingState(ref) : WorkingState.createEmpty();
         }));
     })
-    .spread(function(parent, base, head) {
+    .spread((parent, base, head) => {
         const conflicts = _compareTrees(parent.getTreeEntries(),
                                      base.getTreeEntries(),
                                      head.getTreeEntries());
@@ -95,9 +95,9 @@ function mergeCommit(treeConflict, parents, options) {
 
     // Create map of blobs that needs to be created
     const solvedConflicts = treeConflict.getConflicts();
-    opts.blobs = solvedEntries.filter(function(treeEntry) {
+    opts.blobs = solvedEntries.filter((treeEntry) => {
         return !treeEntry.hasSha();
-    }).map(function(treeEntry, path) {
+    }).map((treeEntry, path) => {
         return solvedConflicts.get(path).getSolvedContent();
     });
 
@@ -120,14 +120,14 @@ function _compareTrees(parentEntries, baseEntries, headEntries) {
     // ... modified by both branches
     const headSet = Immutable.Set.fromKeys(headDiff);
     const baseSet = Immutable.Set.fromKeys(baseDiff);
-    const conflictSet = headSet.intersect(baseSet).filter(function(filepath) {
+    const conflictSet = headSet.intersect(baseSet).filter((filepath) => {
         // ...in different manners
         return !Immutable.is(headDiff.get(filepath), baseDiff.get(filepath));
     });
 
     // Create the map of Conflict
-    return (new Immutable.Map()).withMutations(function(map) {
-        return conflictSet.reduce(function(map, filepath) {
+    return (new Immutable.Map()).withMutations((map) => {
+        return conflictSet.reduce((map, filepath) => {
             const shas = [
                 parentEntries,
                 baseEntries,
@@ -158,8 +158,8 @@ function _diffEntries(parent, child) {
         return !Immutable.is(parent.get(path), child.get(path));
     });
 
-    return (new Immutable.Map()).withMutations(function(map) {
-        return changes.reduce(function(map, path) {
+    return (new Immutable.Map()).withMutations((map) => {
+        return changes.reduce((map, path) => {
             // Add new TreeEntry or null when deleted
             const treeEntry = child.get(path) || null;
             return map.set(path, treeEntry);
@@ -181,7 +181,7 @@ function _getSolvedEntries(treeConflict) {
     const baseDiff = _diffEntries(parentEntries, baseEntries);
     const headDiff = _diffEntries(parentEntries, headEntries);
 
-    const resolvedEntries = treeConflict.getConflicts().map(function(solvedConflict) {
+    const resolvedEntries = treeConflict.getConflicts().map((solvedConflict) => {
         // Convert to TreeEntries (or null for deletion)
         if (solvedConflict.isDeleted()) {
             return null;

--- a/src/utils/directory.js
+++ b/src/utils/directory.js
@@ -25,7 +25,7 @@ function read(repoState, dirName) {
 
     const files = [];
 
-    treeEntries.forEach(function(treeEntry, filepath) {
+    treeEntries.forEach((treeEntry, filepath) => {
         // Ignore git submodules
         if (treeEntry.getType() !== TreeEntry.TYPES.BLOB) return;
         if (!PathUtils.contains(dirName, filepath)) return;
@@ -101,7 +101,7 @@ function readFilenamesRecursive(repoState, dirName) {
     const workingState = repoState.getCurrentState();
     const fileSet = WorkingUtils.getMergedFileSet(workingState);
 
-    return fileSet.filter(function(path) {
+    return fileSet.filter((path) => {
         return PathUtils.contains(dirName, path);
     }).toArray();
 }
@@ -114,7 +114,7 @@ function move(repoState, dirName, newDirName) {
     const filesToMove = readFilenamesRecursive(repoState, dirName);
 
     // Push change to remove all entries
-    return filesToMove.reduce(function(repoState, oldPath) {
+    return filesToMove.reduce((repoState, oldPath) => {
         const newPath = Path.join(
             newDirName,
             Path.relative(dirName, oldPath)
@@ -132,7 +132,7 @@ function remove(repoState, dirName) {
     const filesToRemove = readFilenamesRecursive(repoState, dirName);
 
     // Push change to remove all entries
-    return filesToRemove.reduce(function(repoState, path) {
+    return filesToRemove.reduce((repoState, path) => {
         return FileUtils.remove(repoState, path);
     }, repoState);
 }

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -80,7 +80,7 @@ function stat(repoState, filepath) {
         fileSize = blob.getByteLength();
     } else {
         // It might have been moved (but not fetched)
-        const originalEntry = workingState.getTreeEntries().find(function(entry) {
+        const originalEntry = workingState.getTreeEntries().find((entry) => {
             return entry.getSha() === blobSHA;
         });
         fileSize = originalEntry.getBlobSize();

--- a/src/utils/localFile.js
+++ b/src/utils/localFile.js
@@ -22,7 +22,7 @@ LocalUtils.status = function status(driver) {
  * @return {Promise}
  */
 LocalUtils.track = function track(driver, files, message, author) {
-    files = files.map(function(file) {
+    files = files.map((file) => {
         return LocalFile.create(file);
     });
 

--- a/src/utils/remote.js
+++ b/src/utils/remote.js
@@ -58,11 +58,11 @@ function pull(repoState, driver, opts = {}) {
 
     return driver.pull(opts)
     // Update branch SHA
-    .then(function() {
+    .then(() => {
         return driver.fetchBranches();
     })
-    .then(function(branches) {
-        const updatedBranch = branches.find(function(br) {
+    .then((branches) => {
+        const updatedBranch = branches.find((br) => {
             return br.getFullName() === opts.branch.getFullName();
         });
         repoState = repoState.updateBranch(opts.branch, updatedBranch);

--- a/src/utils/repo.js
+++ b/src/utils/repo.js
@@ -42,7 +42,7 @@ function updateCurrentWorkingState(repoState, workingState) {
 function fetchTree(repoState, driver, branch) {
     // Fetch a working tree for this branch
     return WorkingUtils.fetch(driver, branch)
-    .then(function(newWorkingState) {
+    .then((newWorkingState) => {
         return updateWorkingState(repoState, branch, newWorkingState);
     });
 }
@@ -79,12 +79,12 @@ function checkout(repoState, branch) {
 function fetchBranches(repoState, driver) {
     const oldBranches = repoState.getBranches();
     return driver.fetchBranches()
-    .then(function(branches) {
+    .then((branches) => {
         return repoState.set('branches', branches);
     })
     .then(function refreshWorkingStates(repoState) {
         // Remove outdated WorkingStates
-        return oldBranches.reduce(function(repoState, oldBranch) {
+        return oldBranches.reduce((repoState, oldBranch) => {
             const fullName = oldBranch.getFullName();
             const newBranch = repoState.getBranch(fullName);
             if (newBranch === null || newBranch.getSha() !== oldBranch.getSha()) {
@@ -107,7 +107,7 @@ function fetchBranches(repoState, driver) {
 function initialize(driver) {
     const repoState = RepositoryState.createEmpty();
     return fetchBranches(repoState, driver)
-    .then(function(repoState) {
+    .then((repoState) => {
         const branches = repoState.getBranches();
         const master = branches.find(function isMaster(branch) {
             return branch.getFullName() === 'master';
@@ -115,7 +115,7 @@ function initialize(driver) {
         const branch = master || branches.first();
 
         return fetchTree(repoState, driver, branch)
-        .then(function(repoState) {
+        .then((repoState) => {
             return checkout(repoState, branch);
         });
     });
@@ -137,7 +137,7 @@ function syncFilesystem(driver, branch) {
 function isClean(repoState) {
     return repoState
         .getWorkingStates()
-        .every((workingState) => workingState.isClean());
+        .every(workingState => workingState.isClean());
 }
 
 const RemoteUtils = {

--- a/src/utils/working.js
+++ b/src/utils/working.js
@@ -23,7 +23,7 @@ function getMergedFileSet(workingState) {
  * @return {Map<TreeEntries>}
  */
 function getMergedTreeEntries(workingState) {
-    const removedOrModified = workingState.getChanges().groupBy(function(change, path) {
+    const removedOrModified = workingState.getChanges().groupBy((change, path) => {
         if (change.getType() === CHANGES.REMOVE) {
             return 'remove';
         } else {
@@ -34,7 +34,7 @@ function getMergedTreeEntries(workingState) {
 
     const setToRemove = Immutable.Set.fromKeys(removedOrModified.get('remove', []));
 
-    const withoutRemoved = workingState.getTreeEntries().filter(function(treeEntry, path) {
+    const withoutRemoved = workingState.getTreeEntries().filter((treeEntry, path) => {
         return !setToRemove.contains(path);
     });
 

--- a/test/api.js
+++ b/test/api.js
@@ -31,11 +31,11 @@ const TOKEN = process.env.REPOFS_TOKEN;
 // Commit "Initial commit\n"
 // 1 addition README.md:
 // "# <name of the repo>"
-describe('API tests', function() {
+describe('API tests', () => {
 
     const shouldSkip = process.env.REPOFS_SKIP_API_TEST;
     if (shouldSkip) {
-        it('WAS SKIPPED', function() {
+        it('WAS SKIPPED', () => {
         });
         return;
     }

--- a/test/api/branch.js
+++ b/test/api/branch.js
@@ -12,19 +12,19 @@ function testBranch(driver) {
 
     let repoState;
 
-    before(function() {
+    before(() => {
         return repofs.RepoUtils.initialize(driver)
-        .then(function(initRepo) {
+        .then((initRepo) => {
             repoState = initRepo;
         });
     });
 
-    describe('.create', function() {
-        it('should create a branch and optionally checkout on it', function() {
+    describe('.create', () => {
+        it('should create a branch and optionally checkout on it', () => {
             return repofs.BranchUtils.create(repoState, driver, 'test-branch-create', {
                 checkout: true
             })
-            .then(function(_repoState) {
+            .then((_repoState) => {
                 // Update for next test
                 repoState = _repoState;
                 const master = repoState.getBranch('master');
@@ -36,9 +36,9 @@ function testBranch(driver) {
 
     });
 
-    describe('.merge', function() {
+    describe('.merge', () => {
         // Depends on previous test
-        it('should merge two branches', function() {
+        it('should merge two branches', () => {
             let intoBranch;
             let fromBranch;
             return Q()
@@ -72,19 +72,19 @@ function testBranch(driver) {
                     fetch: true
                 });
             })
-            .then(function(repoState) {
+            .then((repoState) => {
                 repoState = repofs.RepoUtils.checkout(repoState, intoBranch);
                 repofs.FileUtils.exists(repoState, 'merge_branch_file1');
                 repofs.FileUtils.exists(repoState, 'merge_branch_file2');
                 return repofs.FileUtils.fetch(repoState, driver, 'merge_branch_file1');
             })
-            .then(function(repoState) {
+            .then((repoState) => {
                 repofs.FileUtils.read(repoState, 'merge_branch_file1').getAsString()
                     .should.eql('File 1');
             });
         });
 
-        it('should fail with merge conflict', function() {
+        it('should fail with merge conflict', () => {
             let intoBranch;
             let fromBranch;
             return Q()
@@ -118,42 +118,42 @@ function testBranch(driver) {
                     fetch: true
                 });
             })
-            .then(function() {
+            .then(() => {
                 should.fail('CONFLICT was not detected');
-            }, function(err) {
+            }, (err) => {
                 err.code.should.eql(repofs.ERRORS.CONFLICT);
             });
         });
     });
 
-    describe('.update', function() {
-        it('should update an old branch that was updated on the repo', function() {
+    describe('.update', () => {
+        it('should update an old branch that was updated on the repo', () => {
             let oldBranchState;
             let updatedBranch;
 
             return repofs.BranchUtils.create(repoState, driver, 'test-branch-update', {
                 checkout: true
             })
-            .then(function(_repoState) {
+            .then((_repoState) => {
                 oldBranchState = _repoState;
                 return commitAndFlush(_repoState, driver, 'New commit');
             })
-            .then(function(_repoState) {
+            .then((_repoState) => {
                 updatedBranch = _repoState.getCurrentBranch();
                 return repofs.BranchUtils.update(oldBranchState, driver, 'test-branch-update');
             })
-            .then(function(_repoState) {
+            .then((_repoState) => {
                 Immutable.is(updatedBranch, _repoState.getCurrentBranch()).should.be.true();
             });
         });
     });
 
-    describe('.remove', function() {
+    describe('.remove', () => {
         // Depends on previous
-        it('should delete a branch', function() {
+        it('should delete a branch', () => {
             const createdBr = repoState.getBranch('test-branch-create');
             return repofs.BranchUtils.remove(repoState, driver, createdBr)
-            .then(function(_repoState) {
+            .then((_repoState) => {
                 should(_repoState.getBranch('test-branch-create')).be.null();
             });
         });

--- a/test/api/commit.js
+++ b/test/api/commit.js
@@ -10,20 +10,20 @@ function testCommit(driver) {
 
     let repoState;
 
-    before(function() {
+    before(() => {
         return repofs.RepoUtils.initialize(driver)
-        .then(function(initRepo) {
+        .then((initRepo) => {
             return repofs.BranchUtils.create(initRepo, driver, 'test-commit', {
                 checkout: true
             });
         })
-        .then(function(branchedRepo) {
+        .then((branchedRepo) => {
             repoState = branchedRepo;
         });
     });
 
-    describe('.flush', function() {
-        it('should flush a prepared commit', function() {
+    describe('.flush', () => {
+        it('should flush a prepared commit', () => {
             // Create a file for test
             repoState = repofs.FileUtils.create(
                 repoState, 'flushCommitFile', 'Flush CommitContent');
@@ -33,7 +33,7 @@ function testCommit(driver) {
             });
 
             return repofs.CommitUtils.flush(repoState, driver, commitBuilder)
-            .then(function(newState) {
+            .then((newState) => {
                 repoState = newState;
                 // No more pending changes
                 repoState.getCurrentState().isClean().should.be.true();
@@ -43,7 +43,7 @@ function testCommit(driver) {
             });
         });
 
-        it('should detect not fast forward errors', function() {
+        it('should detect not fast forward errors', () => {
             // Simulate another person trying to commit
             const otherState = repofs.FileUtils.create(
                 repoState, 'not_ff_detection', 'I will get a NOT_FAST_FORWARD');
@@ -52,13 +52,13 @@ function testCommit(driver) {
                 repoState, 'not_ff_detection', 'Not ff detection');
 
             return emptyCommitAndFlush(repoState, driver, 'Not ff detection')
-            .then(function(_repoState) {
+            .then((_repoState) => {
                 repoState = _repoState;
                 return emptyCommitAndFlush(otherState, driver, 'Not ff detection');
             })
-            .then(function() {
+            .then(() => {
                 should.fail('NOT_FAST_FORWARD was not detected');
-            }, function(err) {
+            }, (err) => {
                 err.code.should.eql(repofs.ERRORS.NOT_FAST_FORWARD);
                 // Should have the created commit available for merging
                 err.commit.should.be.ok();
@@ -66,23 +66,23 @@ function testCommit(driver) {
         });
     });
 
-    describe('.fetchList', function() {
-        it('should list commits on current branch', function() {
+    describe('.fetchList', () => {
+        it('should list commits on current branch', () => {
             // Work on a different branch
             const listTestState = repofs.RepoUtils.checkout(repoState, 'master');
 
             return repofs.BranchUtils.create(listTestState, driver, 'test-list-commit', {
                 checkout: true
             })
-            .then(function(listTestState) {
+            .then((listTestState) => {
                 return emptyCommitAndFlush(listTestState, driver, 'List commit test');
             })
-            .then(function(listTestState) {
+            .then((listTestState) => {
                 return repofs.CommitUtils.fetchList(driver, {
                     branch: listTestState.getCurrentBranch()
                 });
             })
-            .then(function(commits) {
+            .then((commits) => {
                 commits.count().should.be.greaterThan(1);
                 const commit = commits.first();
                 commit.getAuthor().getName().should.eql('Shakespeare');

--- a/test/api/local.js
+++ b/test/api/local.js
@@ -16,7 +16,7 @@ module.exports = function(driver) {
 };
 
 function testLocal(driver) {
-    describe('.status', function() {
+    describe('.status', () => {
 
         before(function() {
             this.initialReadme = fs.readFileSync(path.join(REPO_DIR, 'README.md'), 'utf8');
@@ -29,9 +29,9 @@ function testLocal(driver) {
             fs.unlinkSync(path.join(REPO_DIR, 'readme2.md'));
         });
 
-        it('should return list of changed files', function(done) {
+        it('should return list of changed files', (done) => {
             LocalUtils.status(driver)
-                .then(function(result) {
+                .then((result) => {
                     const localFiles = result.files;
 
                     // is an immutable list

--- a/test/blob.js
+++ b/test/blob.js
@@ -2,9 +2,9 @@ const should = require('should');
 
 const Blob = require('../src/models/blob');
 
-describe('Blob', function() {
-    it('should fail creating a blob too big', function() {
-        should.throws(function() {
+describe('Blob', () => {
+    it('should fail creating a blob too big', () => {
+        should.throws(() => {
             const ab = new ArrayBuffer(256 * 1024 * 1024);
             Blob.createFromArrayBuffer(ab);
         });

--- a/test/changes.js
+++ b/test/changes.js
@@ -6,7 +6,7 @@ const ChangeUtils = repofs.ChangeUtils;
 
 const mock = require('./mock');
 
-describe('ChangeUtils', function() {
+describe('ChangeUtils', () => {
     const DEFAULT_BOOK = mock.DEFAULT_BOOK;
 
     const create = new Change({
@@ -18,9 +18,9 @@ describe('ChangeUtils', function() {
         type: repofs.CHANGE.REMOVE
     });
 
-    describe('.setChange', function() {
+    describe('.setChange', () => {
 
-        it('should resolve REMOVE after a CREATE', function() {
+        it('should resolve REMOVE after a CREATE', () => {
             let state = DEFAULT_BOOK;
 
             state = ChangeUtils.setChange(DEFAULT_BOOK, 'new', create);
@@ -32,7 +32,7 @@ describe('ChangeUtils', function() {
                 .should.equal(false);
         });
 
-        it('should resolve CREATE after a REMOVE', function() {
+        it('should resolve CREATE after a REMOVE', () => {
             let state = DEFAULT_BOOK;
 
             state = ChangeUtils.setChange(DEFAULT_BOOK, 'README.md', remove);

--- a/test/conflict.js
+++ b/test/conflict.js
@@ -10,7 +10,7 @@ const TreeConflict = repofs.TreeConflict;
 const Conflict = repofs.Conflict;
 const WorkingState = repofs.WorkingState;
 
-describe('ConflictUtils', function() {
+describe('ConflictUtils', () => {
 
     const parentEntries = new Immutable.Map({
         bothDeleted: entry('bothDeleted'),
@@ -80,9 +80,9 @@ describe('ConflictUtils', function() {
 
     // ---- TESTS ----
 
-    describe('._diffEntries', function() {
+    describe('._diffEntries', () => {
 
-        it('should detect modified entries, added entries, and deleted entries', function() {
+        it('should detect modified entries, added entries, and deleted entries', () => {
             const result = ConflictUtils._diffEntries(parentEntries, baseEntries);
 
             const expectedDiff = new Immutable.Map({
@@ -101,9 +101,9 @@ describe('ConflictUtils', function() {
 
     });
 
-    describe('._compareTrees', function() {
+    describe('._compareTrees', () => {
 
-        it('should detect minimum set of conflicts', function() {
+        it('should detect minimum set of conflicts', () => {
             const result = ConflictUtils._compareTrees(parentEntries, baseEntries, headEntries);
             const expected = treeConflict.getConflicts();
 
@@ -112,9 +112,9 @@ describe('ConflictUtils', function() {
 
     });
 
-    describe('.solveTree', function() {
+    describe('.solveTree', () => {
 
-        it('should merge back solved conflicts into a TreeConflict, defaulting to base version', function() {
+        it('should merge back solved conflicts into a TreeConflict, defaulting to base version', () => {
             const solvedTreeConflict = ConflictUtils.solveTree(treeConflict, solvedConflicts);
 
             // Expect tree to be unchanged outside of conflicts
@@ -129,9 +129,9 @@ describe('ConflictUtils', function() {
         });
     });
 
-    describe('._getSolvedEntries', function() {
+    describe('._getSolvedEntries', () => {
 
-        it('should generate the solved tree entries', function() {
+        it('should generate the solved tree entries', () => {
             const solvedTreeConflict = ConflictUtils.solveTree(treeConflict, solvedConflicts);
             const result = ConflictUtils._getSolvedEntries(solvedTreeConflict);
 
@@ -150,7 +150,7 @@ describe('ConflictUtils', function() {
 
     });
 
-    describe('.mergeCommit', function() {
+    describe('.mergeCommit', () => {
         const solvedTreeConflict = ConflictUtils.solveTree(treeConflict, solvedConflicts);
         const mergeCommit = ConflictUtils.mergeCommit(solvedTreeConflict, [
             'parentCommitSha1',
@@ -159,23 +159,23 @@ describe('ConflictUtils', function() {
             author: 'Shakespeare'
         });
 
-        it('should create a merge CommitBuilder with two parents', function() {
+        it('should create a merge CommitBuilder with two parents', () => {
             mergeCommit.getParents().toJS().should.eql([
                 'parentCommitSha1',
                 'parentCommitSha2'
             ]);
         });
 
-        it('should create a merge CommitBuilder with an author', function() {
+        it('should create a merge CommitBuilder with an author', () => {
             mergeCommit.getAuthor().should.eql('Shakespeare');
         });
 
-        it('should create a merge CommitBuilder with solved content as blob', function() {
+        it('should create a merge CommitBuilder with solved content as blob', () => {
             mergeCommit.getBlobs().get('bothModified').getAsString().should.eql('Solved content');
             mergeCommit.getBlobs().count().should.eql(1);
         });
 
-        it('should create a merge CommitBuilder with final solved entries', function() {
+        it('should create a merge CommitBuilder with final solved entries', () => {
             const solvedEntries = new Immutable.Map({
                 deletedModified: entry('deletedModified-head'), // keeped head
                 bothAddedSame: entry('bothAddedSame'),

--- a/test/decoding.js
+++ b/test/decoding.js
@@ -11,7 +11,7 @@ const Branch = require('../src/models/branch');
 const WorkingState = require('../src/models/workingState');
 const RepositoryState = require('../src/models/repositoryState');
 
-describe('Decoding, encoding', function() {
+describe('Decoding, encoding', () => {
 
     const blob = Blob.createFromString('Test');
 
@@ -61,7 +61,7 @@ describe('Decoding, encoding', function() {
         };
     }
 
-    it('should encode and decode back a Blob', function() {
+    it('should encode and decode back a Blob', () => {
         const encoded = Blob.encode(blob);
         const decoded = Blob.decode(encoded);
 

--- a/test/dir.js
+++ b/test/dir.js
@@ -7,7 +7,7 @@ const DirUtils = repofs.DirUtils;
 const FileUtils = repofs.FileUtils;
 const mock = require('./mock');
 
-describe('DirUtils', function() {
+describe('DirUtils', () => {
 
     const INITIAL_FILES = [
         'file.root',
@@ -19,9 +19,9 @@ describe('DirUtils', function() {
 
     const NESTED_DIRECTORY = mock.directoryStructure(INITIAL_FILES);
 
-    describe('.read', function() {
+    describe('.read', () => {
 
-        it('should list files from root', function() {
+        it('should list files from root', () => {
             const files = DirUtils.read(NESTED_DIRECTORY, '.');
             const filenames = _.map(files, method('getPath'));
             _.difference([
@@ -31,7 +31,7 @@ describe('DirUtils', function() {
             ], filenames).should.be.empty();
         });
 
-        it('should list files from dir', function() {
+        it('should list files from dir', () => {
             const files = DirUtils.read(NESTED_DIRECTORY, 'dir.deep/');
             const filenames = _.map(files, method('getPath'));
             _.difference([
@@ -40,8 +40,8 @@ describe('DirUtils', function() {
             ], filenames).should.be.empty();
         });
 
-        it('should differentiate directories and files', function() {
-            const all = _.partition(DirUtils.read(NESTED_DIRECTORY, '.'), function(file) {
+        it('should differentiate directories and files', () => {
+            const all = _.partition(DirUtils.read(NESTED_DIRECTORY, '.'), (file) => {
                 return file.isDirectory();
             });
             const dirs = all[0];
@@ -59,28 +59,28 @@ describe('DirUtils', function() {
             ], dirnames).should.be.empty();
         });
 
-        it('should be flexible with paths', function() {
+        it('should be flexible with paths', () => {
             [
                 'dir.deep',
                 'dir.deep/',
                 './dir.deep/'
             ]
-            .map(function(path) {
+            .map((path) => {
                 return DirUtils.read(NESTED_DIRECTORY, path);
             })
-            .map(function(files) {
+            .map((files) => {
                 return files.map(method('getPath'));
             })
-            .map(function(currentValue, index, array) {
+            .map((currentValue, index, array) => {
                 // Should all equal the first
                 _.difference(currentValue, array[0]).should.be.empty();
             });
         });
     });
 
-    describe('.readRecursive', function() {
+    describe('.readRecursive', () => {
 
-        it('should list files from root', function() {
+        it('should list files from root', () => {
             const files = DirUtils.readRecursive(NESTED_DIRECTORY, '.');
             const filenames = _.map(files, method('getPath'));
             _.difference([
@@ -95,7 +95,7 @@ describe('DirUtils', function() {
             ], filenames).should.be.empty();
         });
 
-        it('should list files from dir', function() {
+        it('should list files from dir', () => {
             const files = DirUtils.readRecursive(NESTED_DIRECTORY, 'dir.deep/');
             const filenames = _.map(files, method('getPath'));
             _.difference([
@@ -105,8 +105,8 @@ describe('DirUtils', function() {
             ], filenames).should.be.empty();
         });
 
-        it('should differentiate directories and files', function() {
-            const all = _.partition(DirUtils.readRecursive(NESTED_DIRECTORY, '.'), function(file) {
+        it('should differentiate directories and files', () => {
+            const all = _.partition(DirUtils.readRecursive(NESTED_DIRECTORY, '.'), (file) => {
                 return file.isDirectory();
             });
             const dirs = all[0];
@@ -129,33 +129,33 @@ describe('DirUtils', function() {
             ], dirnames).should.be.empty();
         });
 
-        it('should be flexible with paths', function() {
+        it('should be flexible with paths', () => {
             [
                 'dir.deep',
                 'dir.deep/',
                 './dir.deep/'
             ]
-            .map(function(path) {
+            .map((path) => {
                 return DirUtils.readRecursive(NESTED_DIRECTORY, path);
             })
-            .map(function(files) {
+            .map((files) => {
                 return files.map(method('getPath'));
             })
-            .map(function(currentValue, index, array) {
+            .map((currentValue, index, array) => {
                 // Should all equal the first
                 _.difference(currentValue, array[0]).should.be.empty();
             });
         });
     });
 
-    describe('.readFilenamesRecursive', function() {
+    describe('.readFilenamesRecursive', () => {
 
-        it('should list filenames recursively from root', function() {
+        it('should list filenames recursively from root', () => {
             const files = DirUtils.readFilenamesRecursive(NESTED_DIRECTORY, '.');
             _.difference(INITIAL_FILES, files).should.be.empty();
         });
 
-        it('should list filenames recursively from dir', function() {
+        it('should list filenames recursively from dir', () => {
             const filesDeep = DirUtils.readFilenamesRecursive(NESTED_DIRECTORY, 'dir/');
             _.difference([
                 'dir/file1',
@@ -163,14 +163,14 @@ describe('DirUtils', function() {
             ], filesDeep).should.be.empty();
         });
 
-        it('should be flexible with paths', function() {
+        it('should be flexible with paths', () => {
             [
                 'dir.deep',
                 'dir.deep/',
                 './dir.deep/'
-            ].map(function(path) {
+            ].map((path) => {
                 return DirUtils.readFilenamesRecursive(NESTED_DIRECTORY, path);
-            }).map(function(files) {
+            }).map((files) => {
                 _.difference([
                     'dir.deep/file1',
                     'dir.deep/dir/file1'
@@ -179,13 +179,13 @@ describe('DirUtils', function() {
         });
     });
 
-    describe('.readFilenames', function() {
-        it('should shallow list root filenames', function() {
+    describe('.readFilenames', () => {
+        it('should shallow list root filenames', () => {
             const files = DirUtils.readFilenames(NESTED_DIRECTORY, './');
             _.difference(['file.root'], files).should.be.empty();
         });
 
-        it('should shallow list all filenames in a dir', function() {
+        it('should shallow list all filenames in a dir', () => {
             const files = DirUtils.readFilenames(NESTED_DIRECTORY, 'dir');
             _.difference([
                 'dir/file1',
@@ -193,7 +193,7 @@ describe('DirUtils', function() {
             ], files).should.be.empty();
         });
 
-        it('should shallow list all filenames and dir in a dir', function() {
+        it('should shallow list all filenames and dir in a dir', () => {
             const files = DirUtils.readFilenames(NESTED_DIRECTORY, './dir.deep/');
             _.difference([
                 'dir.deep/file1',
@@ -202,8 +202,8 @@ describe('DirUtils', function() {
         });
     });
 
-    describe('.move', function() {
-        it('should be able to rename a dir', function() {
+    describe('.move', () => {
+        it('should be able to rename a dir', () => {
             const renamedRepo = DirUtils.move(NESTED_DIRECTORY, 'dir', 'newName');
 
             const files = DirUtils.readFilenamesRecursive(renamedRepo, '.');
@@ -216,7 +216,7 @@ describe('DirUtils', function() {
             ], files).should.be.empty();
         });
 
-        it('should be kind with the cache (keeping SHAs when possible)', function() {
+        it('should be kind with the cache (keeping SHAs when possible)', () => {
             const renamedRepo = DirUtils.move(NESTED_DIRECTORY, 'dir', 'newName');
 
             // The read should not fail because the content should be fetched
@@ -225,8 +225,8 @@ describe('DirUtils', function() {
         });
     });
 
-    describe('.remove', function() {
-        it('should be able to remove a dir', function() {
+    describe('.remove', () => {
+        it('should be able to remove a dir', () => {
             const removedRepo = DirUtils.remove(NESTED_DIRECTORY, 'dir.deep');
 
             const files = DirUtils.readFilenamesRecursive(removedRepo, '.');

--- a/test/file.js
+++ b/test/file.js
@@ -8,31 +8,31 @@ const FILE_TYPE = require('../src/constants/filetype.js');
 
 const mock = require('./mock');
 
-describe('FileUtils', function() {
+describe('FileUtils', () => {
     const DEFAULT_BOOK = mock.DEFAULT_BOOK;
 
-    describe('.exists', function() {
+    describe('.exists', () => {
 
-        it('should true if file exists', function() {
+        it('should true if file exists', () => {
             FileUtils.exists(DEFAULT_BOOK, 'README.md').should.equal(true);
             FileUtils.exists(DEFAULT_BOOK, 'SUMMARY.md').should.equal(true);
         });
 
-        it('should false if file does not exists', function() {
+        it('should false if file does not exists', () => {
             FileUtils.exists(DEFAULT_BOOK, 'Notexist.md').should.equal(false);
             FileUtils.exists(DEFAULT_BOOK, 'dir/SUMMARY.md').should.equal(false);
         });
 
     });
 
-    describe('.read', function() {
-        it('should read content as Blob if file exists', function() {
+    describe('.read', () => {
+        it('should read content as Blob if file exists', () => {
             const blob = FileUtils.read(DEFAULT_BOOK, 'README.md');
             blob.should.be.an.instanceof(Blob);
             blob.getAsString().should.equal('# Introduction');
         });
 
-        it('should read content as Blob for modified files', function() {
+        it('should read content as Blob for modified files', () => {
             const modifiedState = FileUtils.write(DEFAULT_BOOK, 'README.md', 'New');
             const blob = FileUtils.read(modifiedState, 'README.md');
             blob.should.be.an.instanceof(Blob);
@@ -40,8 +40,8 @@ describe('FileUtils', function() {
         });
     });
 
-    describe('.stat', function() {
-        it('should return a File without content when not fetched', function() {
+    describe('.stat', () => {
+        it('should return a File without content when not fetched', () => {
             const repo = mock.addFile(DEFAULT_BOOK, 'notfetched.txt', {
                 fetched: false
             });
@@ -55,7 +55,7 @@ describe('FileUtils', function() {
             should(file.getContent()).not.be.ok();
         });
 
-        it('should return a File with content when fetched', function() {
+        it('should return a File with content when fetched', () => {
             const repo = mock.addFile(DEFAULT_BOOK, 'fetched.txt', {
                 fetched: true
             });
@@ -64,20 +64,20 @@ describe('FileUtils', function() {
             file.getContent().getAsString().should.equal('fetched.txt');
         });
 
-        it('should return a File with content when there is a change', function() {
+        it('should return a File with content when there is a change', () => {
             const repo = FileUtils.create(DEFAULT_BOOK, 'created', 'content');
             const file = FileUtils.stat(repo, 'created');
             file.getContent().getAsString().should.equal('content');
         });
 
-        it('should return a File with content when there is a change with known sha', function() {
+        it('should return a File with content when there is a change with known sha', () => {
             const readmeBlob = FileUtils.read(DEFAULT_BOOK, 'README.md');
             const repo = FileUtils.move(DEFAULT_BOOK, 'README.md', 'renamed');
             const file = FileUtils.stat(repo, 'renamed');
             file.getContent().getAsString().should.equal(readmeBlob.getAsString());
         });
 
-        it('should return a File without content when there is a change with known sha, but not fetched', function() {
+        it('should return a File without content when there is a change with known sha, but not fetched', () => {
             let repo = mock.addFile(DEFAULT_BOOK, 'created', {
                 fetched: false
             });
@@ -88,85 +88,85 @@ describe('FileUtils', function() {
         });
     });
 
-    describe('.readAsString', function() {
-        it('should read content as String if file exists', function() {
+    describe('.readAsString', () => {
+        it('should read content as String if file exists', () => {
             const read = FileUtils.readAsString(DEFAULT_BOOK, 'SUMMARY.md');
             read.should.be.equal('# Summary');
         });
     });
 
-    describe('.create', function() {
-        it('should create a file if it does not exist', function() {
+    describe('.create', () => {
+        it('should create a file if it does not exist', () => {
             const repoState = FileUtils.create(DEFAULT_BOOK, 'New', 'New Content');
             FileUtils.exists(repoState, 'New').should.be.true();
             FileUtils.readAsString(repoState, 'New').should.be.equal('New Content');
         });
 
-        it('should throw File Already Exists when file does exist', function() {
+        it('should throw File Already Exists when file does exist', () => {
             (function createExisting() {
                 FileUtils.create(DEFAULT_BOOK, 'README.md', '');
             }).should.throw(Error, { code: repofs.ERRORS.ALREADY_EXIST });
         });
     });
 
-    describe('.write', function() {
-        it('should write a file if it exists', function() {
+    describe('.write', () => {
+        it('should write a file if it exists', () => {
             const repoState = FileUtils.write(DEFAULT_BOOK, 'README.md', 'New Content');
             FileUtils.readAsString(repoState, 'README.md').should.be.equal('New Content');
         });
 
-        it('should throw File Not Found when file does not exist', function() {
+        it('should throw File Not Found when file does not exist', () => {
             (function writeAbsent() {
                 FileUtils.write(DEFAULT_BOOK, 'Notexist.md', '');
             }).should.throw(Error, { code: repofs.ERRORS.NOT_FOUND });
         });
     });
 
-    describe('.remove', function() {
-        it('should remove a file if it exists', function() {
+    describe('.remove', () => {
+        it('should remove a file if it exists', () => {
             const repoState = FileUtils.remove(DEFAULT_BOOK, 'README.md');
             FileUtils.exists(repoState, 'README.md').should.equal(false);
         });
 
-        it('should throw File Not Found when file does not exist', function() {
+        it('should throw File Not Found when file does not exist', () => {
             (function removeAbsent() {
                 FileUtils.remove(DEFAULT_BOOK, 'Notexist.md');
             }).should.throw(Error, { code: repofs.ERRORS.NOT_FOUND });
         });
     });
 
-    describe('.hasChanged', function() {
-        it('should detect that an existing file has not changed', function() {
+    describe('.hasChanged', () => {
+        it('should detect that an existing file has not changed', () => {
             const state1 = DEFAULT_BOOK;
             const state2 = DEFAULT_BOOK;
             FileUtils.hasChanged(state1, state2, 'README.md').should.be.false();
         });
 
-        it('should detect that a non existing file has not changed', function() {
+        it('should detect that a non existing file has not changed', () => {
             const state1 = DEFAULT_BOOK;
             const state2 = DEFAULT_BOOK;
             FileUtils.hasChanged(state1, state2, 'does_not_exist.md').should.be.false();
         });
 
-        it('should detect that an added file has changed', function() {
+        it('should detect that an added file has changed', () => {
             const state1 = DEFAULT_BOOK;
             const state2 = FileUtils.create(DEFAULT_BOOK, 'created');
             FileUtils.hasChanged(state1, state2, 'created').should.be.true();
         });
 
-        it('should detect that a removed file has changed', function() {
+        it('should detect that a removed file has changed', () => {
             const state1 = DEFAULT_BOOK;
             const state2 = FileUtils.remove(DEFAULT_BOOK, 'README.md');
             FileUtils.hasChanged(state1, state2, 'README.md').should.be.true();
         });
 
-        it('should detect when the content of a file has changed', function() {
+        it('should detect when the content of a file has changed', () => {
             const state1 = FileUtils.create(DEFAULT_BOOK, 'created', 'content1');
             const state2 = FileUtils.write(state1, 'created', 'content2');
             FileUtils.hasChanged(state1, state2, 'created').should.be.true();
         });
 
-        it('should detect when a created file has not changed', function() {
+        it('should detect when a created file has not changed', () => {
             const state1 = FileUtils.create(DEFAULT_BOOK, 'created', 'content1');
             const state2 = FileUtils.write(state1, 'created', 'content1');
             FileUtils.hasChanged(state1, state2, 'created').should.be.false();

--- a/test/filestree.js
+++ b/test/filestree.js
@@ -8,7 +8,7 @@ const FileUtils = repofs.FileUtils;
 const File = require('../src/models/file');
 const mock = require('./mock');
 
-describe('TreeUtils', function() {
+describe('TreeUtils', () => {
 
     const INITIAL_FILES = [
         'file.root',
@@ -20,7 +20,7 @@ describe('TreeUtils', function() {
 
     const REPO = mock.directoryStructure(INITIAL_FILES);
 
-    describe('TreeNode', function() {
+    describe('TreeNode', () => {
         const fileNode1 = createFileNode(REPO, 'dir/file1');
         const fileNode2 = createFileNode(REPO, 'dir/file2');
         let tree = createDirNode('.');
@@ -36,27 +36,27 @@ describe('TreeUtils', function() {
         }));
 
 
-        describe('.getInPath', function() {
-            it('should get a file in a TreeNode from a path', function() {
+        describe('.getInPath', () => {
+            it('should get a file in a TreeNode from a path', () => {
                 const node = TreeUtils.getInPath(tree, 'dir/file1');
                 Immutable.is(fileNode1, node).should.be.true();
             });
 
-            it('should return null when not found', function() {
+            it('should return null when not found', () => {
                 const node = TreeUtils.getInPath(tree, 'dir/notfound');
                 should(node).be.null();
             });
 
-            it('should return the tree itself for root', function() {
+            it('should return the tree itself for root', () => {
                 const node = TreeUtils.getInPath(tree, '.');
                 Immutable.is(tree, node).should.be.true();
             });
         });
     });
 
-    describe('.get', function() {
+    describe('.get', () => {
 
-        it('should create a tree from an empty repo', function() {
+        it('should create a tree from an empty repo', () => {
             const tree = TreeUtils.get(mock.emptyRepo(), '');
             const file = tree.getValue();
             file.getPath().should.eql('.');
@@ -64,7 +64,7 @@ describe('TreeUtils', function() {
             tree.getChildren().isEmpty().should.be.true();
         });
 
-        it('should create a tree from a flat structure of files', function() {
+        it('should create a tree from a flat structure of files', () => {
             const tree = TreeUtils.get(REPO, 'dir');
             const file = tree.getValue();
             file.getPath().should.eql('dir');
@@ -79,14 +79,14 @@ describe('TreeUtils', function() {
             Immutable.is(expected, children).should.be.true();
         });
 
-        it('should create a tree from root', function() {
+        it('should create a tree from root', () => {
             const tree = TreeUtils.get(REPO, '');
             const node = TreeUtils.getInPath(tree, 'dir/file1');
             const expectedNode = createFileNode(REPO, 'dir/file1');
             Immutable.is(expectedNode, node).should.be.true();
         });
 
-        it('should create Immutable objects', function() {
+        it('should create Immutable objects', () => {
             const tree = TreeUtils.get(REPO, '');
             const node = TreeUtils.getInPath(tree, 'dir');
             // Add a file
@@ -96,19 +96,19 @@ describe('TreeUtils', function() {
         });
     });
 
-    describe('.hasChanged', function() {
-        it('should detect when file structure has NOT changed', function() {
+    describe('.hasChanged', () => {
+        it('should detect when file structure has NOT changed', () => {
             const updatedFile = FileUtils.write(REPO, 'dir/file1', 'Content updated');
             TreeUtils.hasChanged(REPO, updatedFile).should.be.false();
         });
 
-        it('should detect when file structure has changed', function() {
+        it('should detect when file structure has changed', () => {
             const removedFile = FileUtils.remove(REPO, 'dir/file1');
             TreeUtils.hasChanged(REPO, removedFile).should.be.true();
         });
     });
 
-    describe('should be performant', function() {
+    describe('should be performant', () => {
         function timeIt(N, maxMS, func) {
             return function() {
                 const t1 = Date.now();

--- a/test/mock.js
+++ b/test/mock.js
@@ -96,7 +96,7 @@ function defaultBook() {
 // dir.deep.oneItem/file1
 // dir.deep.oneItem/dir.oneItem/file1
 function directoryStructure(pathList) {
-    return pathList.reduce(function(repo, path) {
+    return pathList.reduce((repo, path) => {
         return addFile(repo, path);
     }, emptyRepo());
 }
@@ -105,9 +105,9 @@ function directoryStructure(pathList) {
 function bigFileList(n, depth) {
     depth = depth || 1;
     const indexes = Immutable.Range(1, n);
-    return indexes.map(function(index) {
+    return indexes.map((index) => {
         const depths = Immutable.Range(0, depth);
-        return depths.map(function(depth) {
+        return depths.map((depth) => {
             return index + '.' + depth;
         }).toArray().join('/');
     }).toArray();

--- a/test/remote.js
+++ b/test/remote.js
@@ -12,7 +12,7 @@ const REMOTE_PATH = path.resolve('.tmp/repo-remote.git') + '/';
 
 const mock = require('./mock');
 
-describe('RemoteUtils', function() {
+describe('RemoteUtils', () => {
     if (process.env.REPOFS_DRIVER !== 'uhub') return;
 
     const DEFAULT_BOOK = mock.DEFAULT_BOOK;
@@ -105,9 +105,9 @@ describe('RemoteUtils', function() {
     describe('.sync', () => {
         let repoState;
 
-        before(function() {
+        before(() => {
             return repofs.RepoUtils.initialize(driver)
-            .then(function(initRepo) {
+            .then((initRepo) => {
                 repoState = initRepo;
             });
         });

--- a/test/repoUtils.js
+++ b/test/repoUtils.js
@@ -3,22 +3,22 @@ require('should');
 const repofs = require('../src/');
 const mock = require('./mock');
 
-describe('RepoUtils', function() {
+describe('RepoUtils', () => {
 
-    describe('.isClean', function() {
+    describe('.isClean', () => {
 
-        it('should be true for if repo has no change', function() {
+        it('should be true for if repo has no change', () => {
             const repoState = mock.DEFAULT_BOOK;
             repofs.RepoUtils.isClean(repoState).should.equal(true);
         });
 
-        it('should be true for if current branch has changes', function() {
+        it('should be true for if current branch has changes', () => {
             let repoState = mock.DEFAULT_BOOK;
             repoState = repofs.FileUtils.write(repoState, 'README.md', 'New content');
             repofs.RepoUtils.isClean(repoState).should.equal(false);
         });
 
-        it('should be true for if repo has some unclean working states', function() {
+        it('should be true for if repo has some unclean working states', () => {
             let repoState = mock.DEFAULT_BOOK;
             const branch = new repofs.Branch({
                 name: 'newBranch',

--- a/test/repository.js
+++ b/test/repository.js
@@ -2,11 +2,11 @@ require('should');
 
 const repofs = require('../src/');
 
-describe('RepositoryState', function() {
+describe('RepositoryState', () => {
 
-    describe('.createEmpty', function() {
+    describe('.createEmpty', () => {
 
-        it('should create an empty RepoState', function() {
+        it('should create an empty RepoState', () => {
             const repoState = repofs.RepositoryState.createEmpty();
             repoState.should.be.ok();
             repoState.getBranches().isEmpty().should.be.true();

--- a/test/workingState.js
+++ b/test/workingState.js
@@ -3,16 +3,16 @@ require('should');
 const repofs = require('../src/');
 const mock = require('./mock');
 
-describe('WorkingState', function() {
+describe('WorkingState', () => {
 
-    describe('.isClean', function() {
+    describe('.isClean', () => {
 
-        it('should true if workingState has not changes', function() {
+        it('should true if workingState has not changes', () => {
             const repoState = mock.DEFAULT_BOOK;
             repoState.getCurrentState().isClean().should.equal(true);
         });
 
-        it('should false if workingState has changes', function() {
+        it('should false if workingState has changes', () => {
             let repoState = mock.DEFAULT_BOOK;
             repoState = repofs.FileUtils.write(repoState, 'README.md', 'New content');
             repoState.getCurrentState().isClean().should.equal(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,9 +939,9 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-gitbook@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-gitbook/-/eslint-config-gitbook-1.4.0.tgz#a708e247cd05227835017f199bd70af4ba960c14"
+eslint-config-gitbook@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-gitbook/-/eslint-config-gitbook-1.5.0.tgz#1875bafd9e89c11af87e6fa624efb67b380d738a"
   dependencies:
     eslint-plugin-react "^6.3.0"
 


### PR DESCRIPTION
This PR adds a method `Repofs.Commit.fetchCompare`.

It also adds models `Compare` and `FileDiff` (now used in commits).