### PR TITLE
Fix move of non-commited changes

### DIFF
--- a/src/models/blob.js
+++ b/src/models/blob.js
@@ -51,7 +51,7 @@ class Blob extends Record(DEFAULTS) {
     /**
      * @return {Buffer} the blob as Buffer
      */
-    getAsBuffer(encoding) {
+    getAsBuffer() {
         return arrayBuffer.enforceBuffer(this.getContent());
     }
 

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -183,7 +183,8 @@ function move(repoState, filepath, newFilepath) {
         changeNewFile = Change.createCreateFromSha(sha);
     } else {
         // Content not available as blob
-        const contentBuffer = bufferUtils.toBuffer(read(repoState, filepath));
+        const blob = read(repoState, filepath);
+        const contentBuffer = blob.getAsBuffer();
         changeNewFile = Change.createCreate(contentBuffer);
     }
 

--- a/test/file.js
+++ b/test/file.js
@@ -148,7 +148,17 @@ describe('FileUtils', () => {
             }).should.throw(Error, { code: repofs.ERRORS.NOT_FOUND });
         });
 
-        it('should correctly move new files (text)', () => {
+        it('should correctly move existing files', () => {
+            const repoState = FileUtils.move(DEFAULT_BOOK, 'README.md', 'README_NEW.md');
+            FileUtils.exists(repoState, 'README.md').should.equal(false);
+            FileUtils.exists(repoState, 'README_NEW.md').should.equal(true);
+
+            FileUtils.readAsString(DEFAULT_BOOK, 'README.md').should.equal(
+                FileUtils.readAsString(repoState, 'README_NEW.md')
+            );
+        });
+
+        it('should correctly move new files', () => {
             const content = 'Hello world';
 
             const withNewFile = FileUtils.create(DEFAULT_BOOK, 'aNewFile.txt', content);

--- a/test/file.js
+++ b/test/file.js
@@ -135,6 +135,20 @@ describe('FileUtils', () => {
         });
     });
 
+    describe('.move', () => {
+        it('should move a file if it exists', () => {
+            const repoState = FileUtils.remove(DEFAULT_BOOK, 'README.md', 'README_NEW.md');
+            FileUtils.exists(repoState, 'README.md').should.equal(false);
+            FileUtils.exists(repoState, 'README_NEW.md').should.equal(false);
+        });
+
+        it('should throw File Not Found when file does not exist', () => {
+            (function removeAbsent() {
+                FileUtils.move(DEFAULT_BOOK, 'Notexist.md', 'Notexist_new.md');
+            }).should.throw(Error, { code: repofs.ERRORS.NOT_FOUND });
+        });
+    });
+
     describe('.hasChanged', () => {
         it('should detect that an existing file has not changed', () => {
             const state1 = DEFAULT_BOOK;

--- a/test/file.js
+++ b/test/file.js
@@ -137,15 +137,27 @@ describe('FileUtils', () => {
 
     describe('.move', () => {
         it('should move a file if it exists', () => {
-            const repoState = FileUtils.remove(DEFAULT_BOOK, 'README.md', 'README_NEW.md');
+            const repoState = FileUtils.move(DEFAULT_BOOK, 'README.md', 'README_NEW.md');
             FileUtils.exists(repoState, 'README.md').should.equal(false);
-            FileUtils.exists(repoState, 'README_NEW.md').should.equal(false);
+            FileUtils.exists(repoState, 'README_NEW.md').should.equal(true);
         });
 
         it('should throw File Not Found when file does not exist', () => {
             (function removeAbsent() {
                 FileUtils.move(DEFAULT_BOOK, 'Notexist.md', 'Notexist_new.md');
             }).should.throw(Error, { code: repofs.ERRORS.NOT_FOUND });
+        });
+
+        it('should correctly move new files (text)', () => {
+            const content = 'Hello world';
+
+            const withNewFile = FileUtils.create(DEFAULT_BOOK, 'aNewFile.txt', content);
+            const repoState = FileUtils.move(withNewFile, 'aNewFile.txt', 'aNewFile2.txt');
+
+            FileUtils.exists(repoState, 'aNewFile.txt').should.equal(false);
+            FileUtils.exists(repoState, 'aNewFile2.txt').should.equal(true);
+
+            FileUtils.readAsString(repoState, 'aNewFile2.txt').should.equal(content);
         });
     });
 


### PR DESCRIPTION
When moving a file that has a change, the move corrupts the file.

- [x] Add failing tests for `FileUtils.move`
- [x] Fix it